### PR TITLE
Restore compatibility with packaged renderers

### DIFF
--- a/aspen/renderers.py
+++ b/aspen/renderers.py
@@ -1,0 +1,5 @@
+
+# for backwards compatibility with aspen-renderer modules
+from .simplates.renderers import Factory, Renderer
+
+Factory, Renderer # make pyflakes happy

--- a/aspen/simplates/renderers/__init__.py
+++ b/aspen/simplates/renderers/__init__.py
@@ -91,7 +91,7 @@ BUILTIN_RENDERERS = [ 'stdlib_format'
 
 RENDERERS = BUILTIN_RENDERERS[:]
 
-for entrypoint in pkg_resources.iter_entry_points(group='aspen.simplates.renderers'):
+for entrypoint in pkg_resources.iter_entry_points(group='aspen.renderers'):
     RENDERERS.append(entrypoint.name)
 
 RENDERERS.sort()
@@ -113,7 +113,7 @@ def factories(configuration):
         renderer_factories[name] = make_renderer
 
     # import renderers provided by other packages
-    for entrypoint in pkg_resources.iter_entry_points(group='aspen.simplates.renderers'):
+    for entrypoint in pkg_resources.iter_entry_points(group='aspen.renderers'):
         render_module = entrypoint.load()
         renderer_factories[entrypoint.name] = render_module.Factory(configuration)
     return renderer_factories


### PR DESCRIPTION
With all the moving that was done the `aspen/renderers.py` file ended up as `pando/renderers.py` (that's useless and will be deleted soon), and the entry point was changed for no apparent reason.
