### PR TITLE
Fix exception handling in `Mapping.pop()`

### DIFF
--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -48,12 +48,12 @@ class Mapping(dict):
         instead. Otherwise, self.keyerror is called.
 
         """
-        if name not in self:
+        try:
+            values = dict.__getitem__(self, name)
+        except KeyError:
             if default is not NO_DEFAULT:
                 return default
-            else:
-                self.keyerror(name)
-        values = dict.__getitem__(self, name)
+            self.keyerror(name)
         value = values.pop()
         if not values:
             del self[name]

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -116,6 +116,11 @@ def test_mapping_pop_removes_the_item_if_that_was_the_last_value():
     actual = m.keys()
     assert actual == expected
 
+def test_mapping_pop_raises_KeyError_by_default():
+    m = Mapping()
+    with raises(KeyError):
+        m.pop('foo')
+
 def test_mapping_popall_returns_a_list():
     m = Mapping()
     m['foo'] = 1


### PR DESCRIPTION
I introduced this issue while trying to fix another in e21ce884d4844f20949fd190b53106e30b1514be (#4).
