### PR TITLE
Allow modifying initial simplate context, and improve dispatch/negotiation exceptions

### DIFF
--- a/aspen/http/resource.py
+++ b/aspen/http/resource.py
@@ -1,6 +1,6 @@
 from ..output import Output
 from ..request_processor import dispatcher
-from ..simplates.simplate import Simplate, SimplateDefaults, SimplateException
+from ..simplates.simplate import Simplate, SimplateException
 
 
 class Static(object):
@@ -28,23 +28,15 @@ class Static(object):
 class Dynamic(Simplate):
     """Model a dynamic HTTP resource using simplates.
 
-       Most defaults are in request_processor, so make SimplateDefaults from that.
-
        Make .request_processor available as it has been historically.
 
        Figure out which accept header to use.
-
-       Append a charset to text Content-Types if one is known.
-
 
     """
 
     def __init__(self, request_processor, fs, raw, default_media_type):
         self.request_processor = request_processor
-        initial_context = { 'request_processor': request_processor }
-        defaults = SimplateDefaults(request_processor.default_renderers_by_media_type,
-                                    request_processor.renderer_factories,
-                                    initial_context)
+        defaults = request_processor.simplate_defaults
         super(Dynamic, self).__init__(defaults, fs, raw, default_media_type)
 
 

--- a/aspen/request_processor/__init__.py
+++ b/aspen/request_processor/__init__.py
@@ -14,6 +14,7 @@ from algorithm import Algorithm
 from .typecasting import defaults as default_typecasters
 from ..configuration import ConfigurationError, configure, parse
 from ..simplates.renderers import factories
+from ..simplates.simplate import SimplateDefaults
 
 
 default_indices = lambda: ['index.html', 'index.json', 'index',
@@ -137,6 +138,14 @@ class RequestProcessor(object):
 
         self.default_renderers_by_media_type = defaultdict(lambda: self.renderer_default)
         self.default_renderers_by_media_type[self.media_type_json] = 'json_dump'
+
+        # simplate defaults
+        initial_context = { 'request_processor': self }
+        self.simplate_defaults = SimplateDefaults(
+            self.default_renderers_by_media_type,
+            self.renderer_factories,
+            initial_context
+        )
 
         # mime.types
         # ==========

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -21,8 +21,6 @@ class NotFound(DispatchError):
     def __init__(self, message=''):
         DispatchError.__init__(self, message if message else "not found")
 
-class IndirectNegotiationFailure(NotFound): pass
-class DirectNegotiationFailure(NotFound): pass
 class AttemptedBreakout(NotFound): pass
 class UnindexedDirectory(NotFound): pass
 class Redirect(DispatchError): pass

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -346,7 +346,7 @@ def dispatch(indices, media_type_default, pathparts, uripath, startdir):
 
     if result.status == DispatchStatus.okay:
         if result.match.endswith(os.path.sep):
-            raise UnindexedDirectory()
+            raise UnindexedDirectory(result.match)
 
     elif result.status == DispatchStatus.non_leaf:                                # trailing slash
         location = uripath + '/'

--- a/aspen/simplates/simplate.py
+++ b/aspen/simplates/simplate.py
@@ -73,9 +73,16 @@ def _decode(raw):
     return fulltext.decode(encoding or b'ascii')
 
 
-class SimplateException(Exception):
-    def __init__(self, available_types):
+class NegotiationFailure(Exception):
+
+    def __init__(self, accept, available_types):
+        self.accept = accept
         self.available_types = available_types
+        message = "Couldn't satisfy %s. The following media types are available: %s."
+        self.message = message % (self.accept, ', '.join(self.available_types))
+
+    def __str__(self):
+        return self.message
 
 
 class SimplateDefaults(object):
@@ -118,12 +125,12 @@ class Simplate(object):
         self.pages = self.compile_pages(pages)
 
 
-    def best_match(self, accept, default=None):
+    def best_match(self, accept):
         """
         get the media type provided by this simplate that best matches
         the supplied Accept: header, or the default type (that of the
         first template page) if no accept header is provided (is None),
-        or raise SimplateException if no matches are available
+        or raise NegotiationFailure if no matches are available
         to a valid Accept: header.
 
         This is what the simplate will call internally to determine
@@ -140,7 +147,7 @@ class Simplate(object):
                 # Unparseable accept header, accept the default
                 pass
         if media_type == '':    # breakdown in negotiations
-            raise SimplateException(self.available_types)
+            raise NegotiationFailure(accept, self.available_types)
         return media_type
 
 

--- a/tests/test_dynamic_resource.py
+++ b/tests/test_dynamic_resource.py
@@ -7,10 +7,11 @@ from pytest import raises, yield_fixture
 
 from aspen import resources
 from aspen.http.resource import Dynamic
-from aspen.request_processor import dispatcher
+from aspen.request_processor.dispatcher import NotFound
 from aspen.simplates.pagination import Page
 from aspen.simplates.renderers.stdlib_template import Factory as TemplateFactory
 from aspen.simplates.renderers.stdlib_percent import Factory as PercentFactory
+from aspen.simplates.simplate import NegotiationFailure
 
 
 @yield_fixture
@@ -171,13 +172,13 @@ def test_render_raises_if_direct_negotiation_fails(harness):
     harness.fs.www.mk(('index.spt', SIMPLATE))
     state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
     state['accept_header'] = 'cheese/head'
-    raises(dispatcher.DirectNegotiationFailure, _render, state)
+    raises(NegotiationFailure, _render, state)
 
 def test_render_negotation_failures_include_available_types(harness):
     harness.fs.www.mk(('index.spt', SIMPLATE))
     state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
     state['accept_header'] = 'cheese/head'
-    actual = raises(dispatcher.DirectNegotiationFailure, _render, state).value.message
+    actual = raises(NegotiationFailure, _render, state).value.message
     expected = "Couldn't satisfy cheese/head. The following media types are available: " \
                "text/plain, text/html."
     assert actual == expected
@@ -236,7 +237,7 @@ def test_indirect_negotiation_sets_media_type_to_secondary(harness):
     assert actual == expected
 
 def test_indirect_negotiation_with_unsupported_media_type_is_an_error(harness):
-    with raises(dispatcher.IndirectNegotiationFailure):
+    with raises(NotFound):
         harness.simple(INDIRECTLY_NEGOTIATED_SIMPLATE, '/foo.spt', '/foo.jpg')
 
 


### PR DESCRIPTION
This PR is the final set of changes needed to get Pando running on top of Aspen (https://github.com/AspenWeb/pando.py/issues/548).

The first commit allows passing the `website` object to the first page of simplates. The second commit is for autoindexing. The third commit makes it easier to handle negotiation exceptions.
