### PR TITLE
Refactor and improve media type negotiation

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -7,3 +7,15 @@ from __future__ import unicode_literals
 class LoadError(Exception):
     """Represent a problem loading a resource.
     """
+
+
+class NegotiationFailure(Exception):
+
+    def __init__(self, accept, available_types):
+        self.accept = accept
+        self.available_types = available_types
+        message = "Couldn't satisfy %s. The following media types are available: %s."
+        self.message = message % (self.accept, ', '.join(self.available_types))
+
+    def __str__(self):
+        return self.message

--- a/aspen/http/resource.py
+++ b/aspen/http/resource.py
@@ -7,12 +7,11 @@ class Static(object):
     """Model a static HTTP resource.
     """
 
-    def __init__(self, request_processor, fspath, raw, media_type):
+    def __init__(self, request_processor, fspath, raw, fs_media_type):
         assert type(raw) is bytes  # sanity check
         self.raw = raw
-        self.media_type = media_type
-        if media_type == 'application/json':
-            self.media_type = request_processor.media_type_json
+        self.fs_media_type = fs_media_type
+        self.media_type = fs_media_type or request_processor.media_type_default
         self.charset = None
         if request_processor.charset_static:
             try:
@@ -34,9 +33,11 @@ class Dynamic(Simplate):
 
     """
 
-    def __init__(self, request_processor, fs, raw, default_media_type):
+    def __init__(self, request_processor, fs, raw, fs_media_type):
         self.request_processor = request_processor
+        self.fs_media_type = fs_media_type
         defaults = request_processor.simplate_defaults
+        default_media_type = fs_media_type or request_processor.media_type_default
         super(Dynamic, self).__init__(defaults, fs, raw, default_media_type)
 
 

--- a/aspen/http/resource.py
+++ b/aspen/http/resource.py
@@ -57,9 +57,10 @@ class Dynamic(Simplate):
         we can ignore it: <https://tools.ietf.org/html/rfc7231#section-5.3.2>).
         """
         available = self.available_types
-        # When there is an extension in the path, the dispatcher gives us the
+        # When there is an extension in the URI path, the dispatcher gives us the
         # corresponding media type (or an empty string if unknown)
         accept = dispatch_accept = state['dispatch_result'].extra.get('accept')
+
         if accept is not None:
             # If the extension is unknown, raise NotFound
             if accept == '':

--- a/aspen/http/resource.py
+++ b/aspen/http/resource.py
@@ -64,6 +64,10 @@ class Dynamic(Simplate):
             # If the extension is unknown, raise NotFound
             if accept == '':
                 raise NotFound()
+            # Accept `media/type` for `media/x-type`
+            i = accept.find('/x-')
+            if i > 0:
+                accept += ',' + accept[:i+1] + accept[i+3:]
             # Accept custom JSON media type
             if accept == 'application/json':
                 accept += ',' + self.request_processor.media_type_json

--- a/aspen/http/resource.py
+++ b/aspen/http/resource.py
@@ -1,6 +1,10 @@
+
+import mimeparse
+
+from ..exceptions import NegotiationFailure
 from ..output import Output
 from ..request_processor.dispatcher import NotFound
-from ..simplates.simplate import NegotiationFailure, Simplate
+from ..simplates.simplate import Simplate
 
 
 class Static(object):
@@ -28,9 +32,6 @@ class Dynamic(Simplate):
     """Model a dynamic HTTP resource using simplates.
 
        Make .request_processor available as it has been historically.
-
-       Figure out which accept header to use.
-
     """
 
     def __init__(self, request_processor, fs, raw, fs_media_type):
@@ -40,15 +41,50 @@ class Dynamic(Simplate):
         default_media_type = fs_media_type or request_processor.media_type_default
         super(Dynamic, self).__init__(defaults, fs, raw, default_media_type)
 
-
     def render(self, state):
+        """Render the resource with the given state as context, return Output.
+
+        Before rendering we need to determine what type of content we're going
+        to send back, by trying to find a match between the media types the
+        client wants and the ones provided by the resource.
+
+        The two sources for what the client wants are the extension in the
+        request URL, and the Accept header. If the former fails to match we
+        raise NotFound (404), if the latter fails we raise NegotiationFailure
+        (406).
+
+        Note that we don't always respect the `Accept` header (the spec says
+        we can ignore it: <https://tools.ietf.org/html/rfc7231#section-5.3.2>).
+        """
+        available = self.available_types
+        # When there is an extension in the path, the dispatcher gives us the
+        # corresponding media type (or an empty string if unknown)
         accept = dispatch_accept = state['dispatch_result'].extra.get('accept')
-        if accept is None:
-            accept = state.get('accept_header')
-        try:
-            return super(Dynamic, self).render(accept, state)
-        except NegotiationFailure:
-            if dispatch_accept is not None:
-                # e.g. client requested `/foo.json` but `/foo.spt` has no JSON page
+        if accept is not None:
+            # If the extension is unknown, raise NotFound
+            if accept == '':
                 raise NotFound()
-            raise
+            # Accept custom JSON media type
+            if accept == 'application/json':
+                accept += ',' + self.request_processor.media_type_json
+        elif len(available) == 1:
+            # If there's only one available type and no extension in the path,
+            # then we ignore the Accept header
+            return super(Dynamic, self).render(available[0], state)
+        else:
+            accept = state.get('accept_header')
+        if accept:
+            try:
+                best_match = mimeparse.best_match(available, accept)
+            except ValueError:
+                # Unparseable accept header
+                best_match = None
+            if best_match:
+                return super(Dynamic, self).render(best_match, state)
+            elif best_match == '':
+                if dispatch_accept is not None:
+                    # e.g. client requested `/foo.json` but `/foo.spt` has no JSON page
+                    raise NotFound()
+                raise NegotiationFailure(accept, available)
+        # Fall back to the first available type
+        return super(Dynamic, self).render(available[0], state)

--- a/aspen/request_processor/algorithm.py
+++ b/aspen/request_processor/algorithm.py
@@ -49,7 +49,6 @@ def hydrate_querystring(querystring):
 
 def dispatch_path_to_filesystem(request_processor, path, querystring):
     result = dispatcher.dispatch( indices               = request_processor.indices
-                                , media_type_default    = request_processor.media_type_default
                                 , pathparts             = path.parts
                                 , uripath               = path.decoded
                                 , startdir              = request_processor.www_root

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -286,15 +286,13 @@ def is_first_index(indices, basedir, name):
     return False
 
 
-def update_neg_type(media_type_default, capture_accept, filename):
-    media_type = mimetypes.guess_type(filename, strict=False)[0]
-    if media_type is None:
-        media_type = media_type_default
+def update_neg_type(capture_accept, filename):
+    media_type = mimetypes.guess_type(filename, strict=False)[0] or ''
     capture_accept['accept'] = media_type
     debug(lambda: "set result.extra['accept'] to %r" % media_type)
 
 
-def dispatch(indices, media_type_default, pathparts, uripath, startdir):
+def dispatch(indices, pathparts, uripath, startdir):
     """Concretize dispatch_abstract.
     """
 
@@ -306,7 +304,7 @@ def dispatch(indices, media_type_default, pathparts, uripath, startdir):
     is_leaf = os.path.isfile
     traverse = os.path.join
     find_index = lambda x: match_index(indices, x)
-    noext_matched = lambda x: update_neg_type(media_type_default, capture_accept, x)
+    noext_matched = lambda x: update_neg_type(capture_accept, x)
 
 
     # Dispatch!

--- a/aspen/resources.py
+++ b/aspen/resources.py
@@ -110,11 +110,12 @@ def load(request_processor, fspath, mtime):
     if is_spt:
         guess_with = guess_with[:-4]
     fs_media_type = mimetypes.guess_type(guess_with, strict=False)[0]
-    media_type = fs_media_type if fs_media_type else request_processor.media_type_default
+    if fs_media_type == 'application/json':
+        fs_media_type = request_processor.media_type_json
 
     # Compute and instantiate a class.
     # ================================
     # An instantiated resource is compiled as far as we can take it.
 
     Class = Dynamic if is_spt else Static
-    return Class(request_processor, fspath, raw, media_type)
+    return Class(request_processor, fspath, raw, fs_media_type)

--- a/aspen/testing.py
+++ b/aspen/testing.py
@@ -85,11 +85,11 @@ class Harness(object):
         return self._hit('GET', uripath, querystring, **kw)
 
     def _hit(self, method, path='/', querystring='', raise_immediately=True, return_after=None,
-             want='output', **headers):
+             want='output', accept_header=None):
 
         state = self.request_processor.process( path
                                               , querystring
-                                              , accept_header=None
+                                              , accept_header=accept_header
                                               , raise_immediately=raise_immediately
                                               , return_after=return_after
                                                )

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mimetypes
 import os
 from pytest import raises
 
@@ -468,3 +469,27 @@ def test_dont_serve_hidden_files(harness):
 def test_dont_serve_spt_file_source(harness):
     harness.fs.www.mk(('foo.html.spt', "Greetings, program!"),)
     assert_raises_NotFound(harness, '/foo.html.spt')
+
+
+# dispatch_result.extra['accept']
+# ===============================
+
+def test_dispatcher_sets_extra_accept_header(harness):
+    dispatch_result = harness.simple(
+        filepath='foo.spt',
+        uripath='/foo.css',
+        return_after='dispatch_path_to_filesystem',
+        want='dispatch_result',
+    )
+    actual = dispatch_result.extra['accept']
+    expected = mimetypes.guess_type('foo.css', strict=False)[0]
+    assert actual == expected
+
+def test_extra_accept_header_is_empty_string_when_unknown(harness):
+    dispatch_result = harness.simple(
+        filepath='foo.spt',
+        uripath='/foo.unknown-extension',
+        return_after='dispatch_path_to_filesystem',
+        want='dispatch_result',
+    )
+    assert dispatch_result.extra['accept'] == ''

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -275,7 +275,7 @@ def test_virtual_path_file_key_val_cast_custom(harness):
                       , "[-----]\nusername=path['user']\n[-----]\nGreetings, %(username)s!"
                        ),)
     actual = harness.simple(filepath=None, uripath='/user/chad.html', want='path',
-            run_through='apply_typecasters_to_path')
+            return_after='apply_typecasters_to_path')
     assert actual['user'].username == 'chad'
 
 # negotiated *and* virtual paths

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -46,7 +46,6 @@ Greetings, program!
 def test_dispatcher_returns_a_result(harness):
     harness.fs.www.mk(('index.html', 'Greetings, program!'),)
     result = dispatcher.dispatch( indices               = ['index.html']
-                                , media_type_default    = ''
                                 , pathparts             = ['']
                                 , uripath               = '/'
                                 , startdir              = harness.fs.www.root
@@ -59,7 +58,6 @@ def test_dispatcher_returns_a_result(harness):
 def test_dispatcher_raises_for_unindexed_directory(harness):
     with raises(dispatcher.UnindexedDirectory):
         dispatcher.dispatch( indices               = []
-                           , media_type_default    = ''
                            , pathparts             = ['']
                            , uripath               = '/'
                            , startdir              = harness.fs.www.root

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -491,3 +491,12 @@ def test_extra_accept_header_is_empty_string_when_unknown(harness):
         want='dispatch_result',
     )
     assert dispatch_result.extra['accept'] == ''
+
+def test_extra_accept_header_is_missing_when_extension_missing(harness):
+    dispatch_result = harness.simple(
+        filepath='foo.spt',
+        uripath='/foo',
+        return_after='dispatch_path_to_filesystem',
+        want='dispatch_result',
+    )
+    assert 'accept' not in dispatch_result.extra

--- a/tests/test_dynamic_resource.py
+++ b/tests/test_dynamic_resource.py
@@ -20,7 +20,7 @@ def get(harness):
         kw = dict( request_processor = harness.request_processor
                  , fs = ''
                  , raw = b'[---]\n[---] text/plain via stdlib_template\n'
-                 , default_media_type = ''
+                 , fs_media_type = ''
                   )
         kw.update(_kw)
         return Dynamic(**kw)
@@ -64,8 +64,10 @@ def test_parse_specline_doesnt_require_renderer(get):
     actual = (factory.__class__, media_type)
     assert actual == (PercentFactory, 'media/type')
 
-def test_parse_specline_requires_media_type(get):
-    raises(SyntaxError, get()._parse_specline, 'via stdlib_template')
+def test_parse_specline_doesnt_require_media_type(get, harness):
+    factory, media_type = get()._parse_specline('via stdlib_template')
+    actual = (factory.__class__, media_type)
+    assert actual == (TemplateFactory, harness.request_processor.media_type_default)
 
 def test_parse_specline_raises_SyntaxError_if_renderer_is_malformed(get):
     raises(SyntaxError, get()._parse_specline, 'stdlib_template media/type')

--- a/tests/test_dynamic_resource.py
+++ b/tests/test_dynamic_resource.py
@@ -5,13 +5,12 @@ from __future__ import unicode_literals
 
 from pytest import raises, yield_fixture
 
-from aspen import resources
+from aspen.exceptions import NegotiationFailure
 from aspen.http.resource import Dynamic
 from aspen.request_processor.dispatcher import NotFound
 from aspen.simplates.pagination import Page
 from aspen.simplates.renderers.stdlib_template import Factory as TemplateFactory
 from aspen.simplates.renderers.stdlib_percent import Factory as PercentFactory
-from aspen.simplates.simplate import NegotiationFailure
 
 
 @yield_fixture
@@ -112,17 +111,6 @@ def test_get_renderer_factory_can_raise_syntax_error(get):
 
 # render
 
-def _get_state(harness, *a, **kw):
-    kw['return_after'] = 'dispatch_path_to_filesystem'
-    kw['want'] = 'state'
-    return harness.simple(*a, **kw)
-
-
-def _render(state):
-    resource = resources.load(state['request_processor'], state['dispatch_result'].match, 0)
-    state['resource'] = resource
-    return resource.render(state)
-
 SIMPLATE = """\
 [---]
 [---] text/plain
@@ -132,55 +120,38 @@ Greetings, program!
 """
 
 def test_render_is_happy_not_to_negotiate(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    actual = _render(state).body
-    assert actual == "Greetings, program!\n"
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE)
+    assert output.body == "Greetings, program!\n"
 
 def test_render_sets_media_type_when_it_doesnt_negotiate(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    output = _render(state)
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE)
     assert output.media_type == "text/plain"
 
 def test_render_is_happy_not_to_negotiate_with_defaults(harness):
-    harness.fs.www.mk(('index.spt', '''[---]\n[---]\nGreetings, program!\n'''))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    actual = _render(state).body
-    assert actual == "Greetings, program!\n"
+    output = harness.simple(filepath='index.spt', contents="[---]\n[---]\nGreetings, program!\n")
+    assert output.body == "Greetings, program!\n"
 
 def test_render_negotiates(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'text/html'
-    actual = _render(state).body
-    assert actual == "<h1>Greetings, program!</h1>\n"
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='text/html')
+    assert output.body == "<h1>Greetings, program!</h1>\n"
 
-def test_handles_busted_accept(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'text/html;'
-    actual = _render(state).body
-    assert actual == "Greetings, program!\n"
+def test_ignores_busted_accept(harness):
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='text/html;')
+    assert output.body == "Greetings, program!\n"
 
 def test_render_sets_media_type_when_it_negotiates(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'text/html'
-    output = _render(state)
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='text/html')
     assert output.media_type == "text/html"
 
 def test_render_raises_if_direct_negotiation_fails(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'cheese/head'
-    raises(NegotiationFailure, _render, state)
+    with raises(NegotiationFailure):
+        harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='cheese/head')
 
 def test_render_negotation_failures_include_available_types(harness):
-    harness.fs.www.mk(('index.spt', SIMPLATE))
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'cheese/head'
-    actual = raises(NegotiationFailure, _render, state).value.message
+    actual = raises(
+        NegotiationFailure,
+        harness.simple, filepath='index.spt', contents=SIMPLATE, accept_header='cheese/head'
+    ).value.message
     expected = "Couldn't satisfy cheese/head. The following media types are available: " \
                "text/plain, text/html."
     assert actual == expected
@@ -203,17 +174,13 @@ def install_glubber(harness):
 def test_can_override_default_renderers_by_mimetype(harness):
     install_glubber(harness)
     harness.fs.www.mk(('index.spt', SIMPLATE),)
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'text/plain'
-    actual = _render(state).body
-    assert actual == "glubber"
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='text/plain')
+    assert output.body == "glubber"
 
 def test_can_override_default_renderer_entirely(harness):
     install_glubber(harness)
-    state = _get_state(harness, filepath='index.spt', contents=SIMPLATE)
-    state['accept_header'] = 'text/plain'
-    actual = _render(state).body
-    assert actual == "glubber"
+    output = harness.simple(filepath='index.spt', contents=SIMPLATE, accept_header='text/plain')
+    assert output.body == "glubber"
 
 
 # indirect

--- a/tests/test_json_resource.py
+++ b/tests/test_json_resource.py
@@ -51,7 +51,6 @@ def test_json_content_type_is_per_file_configurable(harness):
     expected = 'floober/blah'
     SPT="""
 [---]
-output.media_type = 'floober/blah'
 [---] floober/blah
 {'Greetings': 'program!'}
 """
@@ -163,7 +162,7 @@ def test_aspen_json_dumps_dumps():
 
 # jsonp
 
-JSONP_SIMPLATE = """[---]\n[---] application/javascript via jsonp_dump
+JSONP_SIMPLATE = """[---]\n[---] application/json via jsonp_dump
 {'Greetings': 'program!'}"""
 
 JSONP_RESULT = '''/**/ foo({
@@ -171,7 +170,7 @@ JSONP_RESULT = '''/**/ foo({
 });'''
 
 def _jsonp_query(harness, querystring):
-    return harness.simple(JSONP_SIMPLATE, querystring=querystring).body
+    return harness.simple(JSONP_SIMPLATE, filepath='index.json.spt', querystring=querystring).body
 
 def test_jsonp_basically_works(harness):
     actual = _jsonp_query(harness, "jsonp=foo")
@@ -185,7 +184,7 @@ def test_jsonp_defaults_to_json_with_no_callback(harness):
     expected = '''{
     "Greetings": "program!"
 }'''
-    actual = harness.simple(JSONP_SIMPLATE).body
+    actual = harness.simple(JSONP_SIMPLATE, filepath='index.spt').body
     assert actual == expected, "wanted %r got %r " % (expected, actual)
 
 def test_jsonp_filters_disallowed_chars(harness):

--- a/tests/test_simplates.py
+++ b/tests/test_simplates.py
@@ -80,7 +80,7 @@ foo = 'Template'
 [---] text/plain via stdlib_format
 {foo}
 [---] text/xml
-<foo>{foo}</foo>""")
+<foo>{foo}</foo>""", filepath='index.spt')
     assert response.body.strip() == 'Template'
 
 


### PR DESCRIPTION
The original idea was to move the negotiation to an algorithm function, but in the end I put it in `Dynamic.render()` instead. Either way moving it out of the simplates module should help us with https://github.com/AspenWeb/salon/issues/13.

This PR adds a few tests and fixes a few issues, it should notably make https://github.com/liberapay/liberapay.com/blob/2c03dbfd75e9a747b309bfad64590a0e2aceca05/liberapay/__init__.py#L67-L74 obsolete.
