### PR TITLE
Implement renderer padding to get accurate line numbers in tracebacks

### DIFF
--- a/aspen/simplates/renderers/json_dump.py
+++ b/aspen/simplates/renderers/json_dump.py
@@ -7,8 +7,6 @@ from . import Renderer, Factory
 from .. import json_
 
 class Renderer(Renderer):
-    def compile(self, filepath, raw):
-        return raw
 
     def render_content(self, context):
         output = context['output']

--- a/aspen/simplates/renderers/jsonp_dump.py
+++ b/aspen/simplates/renderers/jsonp_dump.py
@@ -12,6 +12,7 @@ CALLBACK_RE = re.compile(r'[^_a-zA-Z0-9]')
 
 
 class Renderer(JsonRenderer):
+
     def render_content(self, context):
         # get the jsonp callback
         qs = context['querystring']

--- a/aspen/simplates/renderers/stdlib_format.py
+++ b/aspen/simplates/renderers/stdlib_format.py
@@ -7,8 +7,6 @@ from . import Renderer, Factory
 
 
 class Renderer(Renderer):
-    def compile(self, filepath, raw):
-        return raw
 
     def render_content(self, context):
         return self.compiled.format(**context)

--- a/aspen/simplates/renderers/stdlib_percent.py
+++ b/aspen/simplates/renderers/stdlib_percent.py
@@ -7,8 +7,6 @@ from . import Renderer, Factory
 
 
 class Renderer(Renderer):
-    def compile(self, filepath, raw):
-        return raw
 
     def render_content(self, context):
         return self.compiled % context

--- a/aspen/simplates/renderers/stdlib_template.py
+++ b/aspen/simplates/renderers/stdlib_template.py
@@ -6,9 +6,11 @@ from __future__ import unicode_literals
 from . import Renderer, Factory
 from string import Template
 
+
 class Renderer(Renderer):
-    def compile(self, filepath, raw):
-        return Template(raw)
+
+    def compile(self, filepath, padded):
+        return Template(padded)
 
     def render_content(self, context):
         return self.compiled.substitute(context)

--- a/aspen/simplates/simplate.py
+++ b/aspen/simplates/simplate.py
@@ -105,7 +105,7 @@ class Simplate(object):
         self.decoded = _decode(raw)                   # type: unicode
         self.default_media_type = default_media_type  # type: str
 
-        self.renderers = {}         # mapping of media type to render function
+        self.renderers = {}         # mapping of media type to Renderer objects
         self.available_types = []   # ordered sequence of media types
         pages = self.parse_into_pages(self.decoded)
         self.pages = self.compile_pages(pages)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -3,6 +3,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from pytest import raises
+
 from aspen.simplates import json_
 from aspen.simplates.renderers import Factory, Renderer
 
@@ -33,3 +35,53 @@ def test_a_custom_renderer(harness):
     assert d['media_type'] == 'text/html'
     assert d['offset'] == 2
     assert d['compiled'] == 'LOREM IPSUM'
+
+
+def test_renderer_padding_works_with_padded_output(harness):
+    class TestRenderer(Renderer):
+
+        def compile(self, filepath, padded):
+            assert padded[:self.offset] == b'\n' * self.offset
+            return padded
+
+        def render_content(self, context):
+            return b'\n' + self.compiled + b'\n'
+
+    class TestFactory(Factory):
+        Renderer = TestRenderer
+
+    request_processor = harness.request_processor
+    request_processor.renderer_factories['x'] = TestFactory(request_processor)
+
+    output = harness.simple("[---]\n[---] text/plain via x\nSome text")
+    assert output.body == '\nSome text\n'
+
+
+def test_renderer_padding_works_with_stripped_output(harness):
+    class TestRenderer(Renderer):
+
+        def compile(self, filepath, padded):
+            assert padded[:self.offset] == b'\n' * self.offset
+            return padded
+
+        def render_content(self, context):
+            return b'\n' + self.raw + b'\n'
+
+    class TestFactory(Factory):
+        Renderer = TestRenderer
+
+    request_processor = harness.request_processor
+    request_processor.renderer_factories['y'] = TestFactory(request_processor)
+
+    output = harness.simple("[---]\n[---] text/plain via y\nSome text")
+    assert output.body == '\nSome text\n'
+
+
+def test_renderer_padding_achieves_correct_line_numbers_in_tracebacks(harness):
+    harness.fs.www.mk(('index.html.spt', '''\
+    [---]
+    [---] text/html via stdlib_template
+    Greetings, $!
+    '''))
+    actual = str(raises(ValueError, harness._hit, 'GET', '/').value)
+    assert 'line 3' in actual


### PR DESCRIPTION
See https://github.com/AspenWeb/pando.py/issues/284.
