### PR TITLE
Optimize dispatch table tests

### DIFF
--- a/tests/dispatch_table_test.py
+++ b/tests/dispatch_table_test.py
@@ -90,20 +90,14 @@ def test_all_table_entries(harness, files, request_uri, expected):
     # set up the specified files
     realfiles = tuple([ f if f.endswith('/') else (f, GENERIC_SPT) for f in files ])
     harness.fs.www.mk(*realfiles)
-    # make the request and get the response code and the request object (sadly we can't get both with one request)
     try:
-        harness.simple(uripath=request_uri, filepath=None)
+        state = harness._hit('GET', request_uri, want='state')
     except dispatcher.NotFound:
         result = '404'
     except dispatcher.Redirect as err:
         result = '302 ' + err.message
     else:
         result = '200'
-        state = harness.simple( uripath=request_uri
-                              , filepath=None
-                              , want='state'
-                              , raise_immediately=False
-                               )
         path = format_result(**state)
         if os.sep != posixpath.sep:
             path = path.replace(os.sep, posixpath.sep)

--- a/tests/dispatch_table_test.py
+++ b/tests/dispatch_table_test.py
@@ -91,7 +91,8 @@ def test_all_table_entries(harness, files, request_uri, expected):
     realfiles = tuple([ f if f.endswith('/') else (f, GENERIC_SPT) for f in files ])
     harness.fs.www.mk(*realfiles)
     try:
-        state = harness._hit('GET', request_uri, want='state')
+        state = harness._hit('GET', request_uri, want='state',
+                             return_after='dispatch_path_to_filesystem')
     except dispatcher.NotFound:
         result = '404'
     except dispatcher.Redirect as err:


### PR DESCRIPTION
I was curious as to why they're so slow compared to the other tests, turns out it's because using `pytest.mark.parametrize` is 5 times slower on my system than doing a simple loop. However I'm not sure that's sufficient reason to stop using it, so for now this PR only contains small improvements that don't impact the running time much but are still nice to have.

Here's the diff to apply if you want to test the difference between `pytest.mark.parametrize` and a simple loop:

``` diff
--- a/tests/dispatch_table_test.py
+++ b/tests/dispatch_table_test.py
@@ -85,8 +85,15 @@ GENERIC_SPT = """
 Greetings, Program!
 """

-@pytest.mark.parametrize("files,request_uri,expected", get_table_entries())
-def test_all_table_entries(harness, files, request_uri, expected):
+def test_all_table_entries(harness):
+    for files, request_uri, expected in get_table_entries():
+        _test_table_entry(harness, files, request_uri, expected)
+        harness.fs.www.remove()
+        harness.fs.www.__init__()
+
+def _test_table_entry(harness, files, request_uri, expected):
     # set up the specified files
     realfiles = tuple([ f if f.endswith('/') else (f, GENERIC_SPT) for f in files ])
     harness.fs.www.mk(*realfiles)
```
