### PR TITLE
Tweak simplate compilation

### DIFF
--- a/aspen/simplates/simplate.py
+++ b/aspen/simplates/simplate.py
@@ -197,7 +197,7 @@ class Simplate(object):
         two = compile(two.padded_content, self.fs, 'exec')
 
         pages[:2] = (one, two)
-        pages[2:] = (self.compile_page(page) for page in pages[2:])
+        pages[2:] = [self.compile_page(page) for page in pages[2:]]
 
         return pages
 


### PR DESCRIPTION
To avoid masking `StopIteration` exceptions. In my case it was raised by `next()` in a renderer, and it took me a while to figure that out.

``` python
>>> def f():
...     raise StopIteration
...
>>> l = []
>>> l[:] = (f() for i in range(2)); l
[]
>>> l[:] = [f() for i in range(2)]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in f
StopIteration
```
