### PR TITLE
Prune dead links to aspen.io

### DIFF
--- a/aspen/simplates/json_.py
+++ b/aspen/simplates/json_.py
@@ -77,9 +77,7 @@ def lazy_check():
     if _json is None:
         raise ImportError("Neither simplejson nor json was found. Try "
                           "installing simplejson to use dynamic JSON "
-                          "simplates. See "
-                          "http://aspen.io/simplates/json/#libraries for "
-                          "more information.")
+                          "simplates.")
 
 
 # Main public API.

--- a/aspen/simplates/renderers/__init__.py
+++ b/aspen/simplates/renderers/__init__.py
@@ -1,10 +1,6 @@
 """
 This module implements pluggable content rendering.
 
-See user docs here:
-
-    http://aspen.io/simplates/rendered/
-
 Negotiated and rendered resources have content pages the bytes for which are
 transformed based on context. The user may explicitly choose a renderer per
 content page, with the default renderer per page computed from its media type.


### PR DESCRIPTION
They're already dead and we haven't even pushed the new aspen.io yet, so they're very old links.
