### PR TITLE
Fix handling of KeyError in Mapping.all()

### DIFF
--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -62,12 +62,9 @@ class Mapping(dict):
     popall = dict.pop
 
     def all(self, name):
-        """Given a name, return a list of values.
+        """Given a name, return a list of values, possibly empty.
         """
-        try:
-            return dict.__getitem__(self, name)
-        except KeyError:
-            self.keyerror(name)
+        return dict.get(self, name, [])
 
     def get(self, name, default=None):
         """Override to only return the last value.

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -57,6 +57,12 @@ def test_mapping_all_returns_list_of_all_values():
     actual = m.all('foo')
     assert actual == expected
 
+def test_mapping_all_returns_empty_list_when_key_is_missing():
+    m = Mapping()
+    expected = []
+    actual = m.all('foo')
+    assert actual == expected
+
 def test_mapping_ones_returns_list_of_last_values():
     m = Mapping()
     m['foo'] = 1


### PR DESCRIPTION
Closes https://github.com/AspenWeb/pando.py/issues/429.
