### PR TITLE
Remove deprecated yield usages in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from aspen.testing import Harness, teardown
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sys_path_scrubber():
     before = set(sys.path)
     yield
@@ -18,7 +18,7 @@ def sys_path_scrubber():
         sys.path.remove(name)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def harness(sys_path_scrubber):
     harness = Harness()
     yield harness


### PR DESCRIPTION
Yield tests and fixtures are deprecated in pytest 3.0, to be removed in 4.0. This removes warnings in test output.
