### PR TITLE
Clean up the `resources` module

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -27,11 +27,6 @@ class ConfigurationError(Exception):
         return self.msg
 
 
-class LoadError(Exception):
-    """Represent a problem loading a resource.
-    """
-
-
 class NegotiationFailure(Exception):
 
     def __init__(self, accept, available_types):

--- a/aspen/resources.py
+++ b/aspen/resources.py
@@ -6,68 +6,40 @@ from __future__ import unicode_literals
 import mimetypes
 import os
 import stat
-import sys
-import traceback
 
-from .exceptions import LoadError
 from .http.resource import Static
 
 
 __cache__ = dict()  # cache, keyed to filesystem path
 
 
-class Entry:
+class Entry(object):
     """An entry in the global resource cache.
     """
+    __slots__ = ('fspath', 'mtime', 'resource')
 
-    fspath = ''  # The filesystem path [string]
-    mtime = None  # The timestamp of the last change [int]
-    quadruple = None  # A post-processed version of the data [4-tuple]
-    exc = None  # Any exception in reading or compilation [Exception]
-
-    def __init__(self):
-        self.fspath = ''
-        self.mtime = 0
-        self.quadruple = ()
+    def __init__(self, fspath, mtime, resource):
+        #: The filesystem path [string]
+        self.fspath = fspath
+        #: The timestamp of the last change [int]
+        self.mtime = mtime
+        #: The loaded resource [Static or Dynamic]
+        self.resource = resource
 
 
 def get(request_processor, fspath):
     """Given a RequestProcessor and a filesystem path, return a Resource object (with caching).
     """
 
-    # XXX This is not thread-safe. It used to be, but then I simplified it
-    # when I switched to diesel. Now that we have multiple engines, some of
-    # which are threaded, we need to make this thread-safe again.
-
     # Get a cache Entry object.
-    # =========================
-
-    if fspath not in __cache__:
-        entry = Entry()
-        __cache__[fspath] = entry
-
-    entry = __cache__[fspath]
-
+    entry = __cache__.get(fspath)
 
     # Process the resource.
-    # =====================
-
-    mtime = os.stat(fspath)[stat.ST_MTIME]
-    if entry.mtime == mtime:  # cache hit
-        if entry.exc is not None:
-            raise entry.exc
-    else:  # cache miss
-        try:
-            entry.resource = load(request_processor, fspath, mtime)
-        except:  # capture any Exception
-            entry.exc = (LoadError(traceback.format_exc()), sys.exc_info()[2])
-        else:  # reset any previous Exception
-            entry.exc = None
-
-        entry.mtime = mtime
-        if entry.exc is not None:
-            raise entry.exc[0]  # TODO Why [0] here, and not above?
-
+    if not entry or request_processor.changes_reload:
+        mtime = os.stat(fspath)[stat.ST_MTIME]
+        if getattr(entry, 'mtime', None) != mtime:  # cache miss
+            resource = load(request_processor, fspath)
+            entry = __cache__[fspath] = Entry(fspath, mtime, resource)
 
     # Return
     # ======
@@ -77,8 +49,8 @@ def get(request_processor, fspath):
     return entry.resource
 
 
-def load(request_processor, fspath, mtime):
-    """Given a RequestProcessor, an fspath, and an mtime, return a Resource object (w/o caching).
+def load(request_processor, fspath):
+    """Given a RequestProcessor and a filesystem path, return a Resource object (w/o caching).
     """
 
     Class = request_processor.get_resource_class(fspath)

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -4,12 +4,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from aspen.resources import LoadError
 from pytest import raises
 
 
 def test_non_ascii_bytes_fail_without_encoding(harness):
-    raises(LoadError, harness.simple, ("""
+    raises(UnicodeDecodeError, harness.simple, ("""
         [------------------]
         text = u'א'
         [------------------]


### PR DESCRIPTION
- make the cache thread-safe again
- clean up exception handling: stop caching them
- honor the `changes_reload` configuration setting
- optimize the speed and memory usage of the `Entry` class: define `__slots__` and drop the unused attribute `quadruple`
