### PR TITLE
Clean up the `DispatchResult` type

### DIFF
--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -54,14 +54,13 @@ class DispatchStatus(object):
     okay, missing, non_leaf = range(3)
 
 
-DispatchResult = namedtuple('DispatchResult', 'status match wildcards detail extension constrain_path')
+DispatchResult = namedtuple('DispatchResult', 'status match wildcards detail extension')
 """
     status - A DispatchStatus object encoding the overall result
     match - the matching path (if status != 'missing')
     wildcards - a dict of whose keys are wildcard path parts, and values are as supplied by the path
     detail - a human readable message describing the result
     extension - e.g. `json` when `foo.spt` is matched to `foo.json`
-    constrain_path - whether the resultant path is below the supplied startnode
 """
 
 
@@ -103,7 +102,7 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
             ext = lastnode_ext if lastnode_ext in wildleafs else None
             curnode, wildvals = wildleafs[ext]
             debug(lambda: "Wildcard leaf match %r and ext %r" % (curnode, ext))
-            return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", None, True)
+            return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", None)
         return None
 
     for depth, node in enumerate(nodepath):
@@ -154,7 +153,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                              , wildvals
                                              , "Found."
                                              , None
-                                             , True
                                               )
             elif node in subnodes and is_leaf_node(node):
                 debug(lambda: "...found exact file, must be static")
@@ -164,7 +162,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                          , None
                                          , "Node %r Not Found" % node
                                          , None
-                                         , True
                                           )
                 else:
                     found_n = node
@@ -193,7 +190,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                          , None
                                          , "Tried to access non-leaf node as leaf."
                                          , None
-                                         , True
                                           )
                 return result
             elif node in subnodes:
@@ -203,7 +199,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                      , None
                                      , "Tried to access non-leaf node as leaf."
                                      , None
-                                     , True
                                       )
             else:
                 debug(lambda: "fallthrough")
@@ -214,7 +209,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                          , None
                                          , "Node %r Not Found" % node
                                          , None
-                                         , True
                                           )
                 return result
 
@@ -240,11 +234,10 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                                          , None
                                          , "Node %r Not Found" % node
                                          , None
-                                         , True
                                           )
                 return result
 
-    return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", extension, True)
+    return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", extension)
 
 
 def match_index(indices, indir):
@@ -327,7 +320,7 @@ def dispatch(indices, is_dynamic, pathparts, uripath, startdir):
     # Protect against escaping the www_root.
     # ======================================
 
-    if result.constrain_path and not result.match.startswith(startdir):
+    if not result.match.startswith(startdir):
         raise exceptions.AttemptedBreakout()
 
     return result

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -54,12 +54,11 @@ class DispatchStatus(object):
     okay, missing, non_leaf = range(3)
 
 
-DispatchResult = namedtuple('DispatchResult', 'status match wildcards detail extension')
+DispatchResult = namedtuple('DispatchResult', 'status match wildcards extension')
 """
     status - A DispatchStatus object encoding the overall result
     match - the matching path (if status != 'missing')
     wildcards - a dict of whose keys are wildcard path parts, and values are as supplied by the path
-    detail - a human readable message describing the result
     extension - e.g. `json` when `foo.spt` is matched to `foo.json`
 """
 
@@ -102,7 +101,7 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
             ext = lastnode_ext if lastnode_ext in wildleafs else None
             curnode, wildvals = wildleafs[ext]
             debug(lambda: "Wildcard leaf match %r and ext %r" % (curnode, ext))
-            return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", None)
+            return DispatchResult(DispatchStatus.okay, curnode, wildvals, None)
         return None
 
     for depth, node in enumerate(nodepath):
@@ -151,7 +150,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                         return DispatchResult( DispatchStatus.okay
                                              , curnode
                                              , wildvals
-                                             , "Found."
                                              , None
                                               )
             elif node in subnodes and is_leaf_node(node):
@@ -160,7 +158,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                     return DispatchResult( DispatchStatus.missing
                                          , None
                                          , None
-                                         , "Node %r Not Found" % node
                                          , None
                                           )
                 else:
@@ -188,7 +185,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                     return DispatchResult( DispatchStatus.non_leaf
                                          , curnode
                                          , None
-                                         , "Tried to access non-leaf node as leaf."
                                          , None
                                           )
                 return result
@@ -197,7 +193,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                 return DispatchResult( DispatchStatus.non_leaf
                                      , curnode
                                      , None
-                                     , "Tried to access non-leaf node as leaf."
                                      , None
                                       )
             else:
@@ -207,7 +202,6 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                     return DispatchResult( DispatchStatus.missing
                                          , None
                                          , None
-                                         , "Node %r Not Found" % node
                                          , None
                                           )
                 return result
@@ -232,12 +226,11 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                     return DispatchResult( DispatchStatus.missing
                                          , None
                                          , None
-                                         , "Node %r Not Found" % node
                                          , None
                                           )
                 return result
 
-    return DispatchResult(DispatchStatus.okay, curnode, wildvals, "Found.", extension)
+    return DispatchResult(DispatchStatus.okay, curnode, wildvals, extension)
 
 
 def match_index(indices, indir):

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -147,19 +147,11 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                         curnode = traverse(curnode, found_n)
                         node_name = found_n[1:-4]  # strip leading % and trailing .spt
                         wildvals[node_name] = node
-                        return DispatchResult( DispatchStatus.okay
-                                             , curnode
-                                             , wildvals
-                                             , None
-                                              )
+                        return DispatchResult(DispatchStatus.okay, curnode, wildvals, None)
             elif node in subnodes and is_leaf_node(node):
                 debug(lambda: "...found exact file, must be static")
                 if is_dynamic_node(node):
-                    return DispatchResult( DispatchStatus.missing
-                                         , None
-                                         , None
-                                         , None
-                                          )
+                    return DispatchResult(DispatchStatus.missing, None, None, None)
                 else:
                     found_n = node
             elif node + ".spt" in subnodes and is_leaf_node(node + ".spt"):
@@ -182,28 +174,16 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                 curnode = traverse(curnode, found_n)
                 result = get_wildleaf_fallback()
                 if not result:
-                    return DispatchResult( DispatchStatus.non_leaf
-                                         , curnode
-                                         , None
-                                         , None
-                                          )
+                    return DispatchResult(DispatchStatus.non_leaf, curnode, None, None)
                 return result
             elif node in subnodes:
                 debug(lambda: "exact dirmatch")
-                return DispatchResult( DispatchStatus.non_leaf
-                                     , curnode
-                                     , None
-                                     , None
-                                      )
+                return DispatchResult(DispatchStatus.non_leaf, curnode, None, None)
             else:
                 debug(lambda: "fallthrough")
                 result = get_wildleaf_fallback()
                 if not result:
-                    return DispatchResult( DispatchStatus.missing
-                                         , None
-                                         , None
-                                         , None
-                                          )
+                    return DispatchResult(DispatchStatus.missing, None, None, None)
                 return result
 
         if not last_node:  # not at last path seg in request
@@ -223,11 +203,7 @@ def dispatch_abstract(listnodes, is_dynamic, is_leaf, traverse, find_index, star
                 debug(lambda: "No exact match for " + repr(node))
                 result = get_wildleaf_fallback()
                 if not result:
-                    return DispatchResult( DispatchStatus.missing
-                                         , None
-                                         , None
-                                         , None
-                                          )
+                    return DispatchResult(DispatchStatus.missing, None, None, None)
                 return result
 
     return DispatchResult(DispatchStatus.okay, curnode, wildvals, extension)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -54,7 +54,6 @@ def test_dispatcher_returns_a_result(harness):
     assert result.status == dispatcher.DispatchStatus.okay
     assert result.match == os.path.join(harness.fs.www.root, 'index.html')
     assert result.wildcards == {}
-    assert result.detail == 'Found.'
 
 def test_dispatcher_raises_for_unindexed_directory(harness):
     with raises(exceptions.UnindexedDirectory):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import mimetypes
 import os
 from pytest import raises
 
@@ -472,8 +471,8 @@ def test_dont_serve_spt_file_source(harness):
     assert_raises_NotFound(harness, '/foo.html.spt')
 
 
-# dispatch_result.extra['accept']
-# ===============================
+# dispatch_result.extension
+# =========================
 
 def test_dispatcher_sets_extra_accept_header(harness):
     dispatch_result = harness.simple(
@@ -482,9 +481,7 @@ def test_dispatcher_sets_extra_accept_header(harness):
         return_after='dispatch_path_to_filesystem',
         want='dispatch_result',
     )
-    actual = dispatch_result.extra['accept']
-    expected = mimetypes.guess_type('foo.css', strict=False)[0]
-    assert actual == expected
+    assert dispatch_result.extension == 'css'
 
 def test_extra_accept_header_is_empty_string_when_unknown(harness):
     dispatch_result = harness.simple(
@@ -493,7 +490,7 @@ def test_extra_accept_header_is_empty_string_when_unknown(harness):
         return_after='dispatch_path_to_filesystem',
         want='dispatch_result',
     )
-    assert dispatch_result.extra['accept'] == ''
+    assert dispatch_result.extension == 'unknown-extension'
 
 def test_extra_accept_header_is_missing_when_extension_missing(harness):
     dispatch_result = harness.simple(
@@ -502,4 +499,4 @@ def test_extra_accept_header_is_missing_when_extension_missing(harness):
         return_after='dispatch_path_to_filesystem',
         want='dispatch_result',
     )
-    assert 'accept' not in dispatch_result.extra
+    assert dispatch_result.extension is None

--- a/tests/test_simplates.py
+++ b/tests/test_simplates.py
@@ -8,7 +8,7 @@ import pytest
 from pytest import raises, fixture
 
 from aspen.exceptions import NegotiationFailure, NotFound
-from aspen.request_processor.dispatcher import mimetypes
+from aspen.http.resource import mimetypes
 from aspen.simplates.simplate import _decode
 from aspen.simplates.simplate import Simplate
 from aspen.simplates.pagination import Page


### PR DESCRIPTION
- replace the `.extra` attribute (a dict that only ever contains one item) with a `.extension`
- drop the `.constrain_path` attribute, its value is always `True`
- drop the `.detail` attribute, it doesn't provide any additional information compared to `.status`