### PR TITLE
Create a `dispatcher_class` configuration knob

### DIFF
--- a/aspen/request_processor/__init__.py
+++ b/aspen/request_processor/__init__.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 
 from algorithm import Algorithm
 
+from .dispatcher import SystemDispatcher
 from .typecasting import defaults as default_typecasters
 from ..http.resource import Static
 from ..exceptions import ConfigurationError
@@ -40,6 +41,7 @@ default_indices = [
 KNOBS = {
     'changes_reload': False,
     'charset_static': None,
+    'dispatcher_class': SystemDispatcher,
     'encode_output_as': 'UTF-8',
     'indices': default_indices,
     'media_type_default': 'text/plain',
@@ -152,6 +154,11 @@ class RequestProcessor(object):
 
         # set up dynamic class mapping
         self.dynamic_classes_by_file_extension = dict(spt=Simplate)
+
+        # create the dispatcher
+        self.dispatcher = self.dispatcher_class(
+            self.www_root, self.is_dynamic, self.indices, self.typecasters
+        )
 
         # mime.types
         # ==========

--- a/aspen/request_processor/algorithm.py
+++ b/aspen/request_processor/algorithm.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from . import dispatcher, typecasting
+from . import typecasting
 from .dispatcher import DispatchStatus
 from .. import resources
 from ..http.request import Path, Querystring
@@ -17,13 +17,8 @@ def hydrate_querystring(querystring):
     return {'querystring': Querystring(querystring)}
 
 
-def dispatch_path_to_filesystem(request_processor, path, querystring):
-    result = dispatcher.dispatch( indices               = request_processor.indices
-                                , is_dynamic            = request_processor.is_dynamic
-                                , pathparts             = path.parts
-                                , uripath               = path.decoded
-                                , startdir              = request_processor.www_root
-                                 )
+def dispatch_path_to_filesystem(request_processor, path):
+    result = request_processor.dispatcher.dispatch(path.decoded, path.parts)
     if result.wildcards:
         for k, v in result.wildcards.items():
             path[k] = v

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -3,10 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import os
-import posixpath
 from collections import namedtuple
 from functools import reduce
+import os
+import posixpath
 
 from ..utils import Constant
 
@@ -61,7 +61,7 @@ DispatchResult = namedtuple('DispatchResult', 'status match wildcards extension 
 """
     status - A DispatchStatus constant encoding the overall result
     match - the matching path (if status != 'missing')
-    wildcards - a dict of whose keys are wildcard path parts, and values are as supplied by the path
+    wildcards - a dict whose keys are wildcard names, and values are as supplied by the path
     extension - e.g. `json` when `foo.spt` is matched to `foo.json`
     canonical - the canonical path of the resource, e.g. `/` for `/index.html`
 """


### PR DESCRIPTION
This branch makes it possible to have multiple dispatcher implementations in Aspen and allows users to select the one they want to use.