### PR TITLE
Eliminate warnings about invalid escapes

### DIFF
--- a/aspen/simplates/pagination.py
+++ b/aspen/simplates/pagination.py
@@ -6,9 +6,9 @@ from __future__ import unicode_literals
 import re
 
 
-SPLITTER = '^\[---+\](?P<header>.*?)(\n|$)'
-ESCAPED_SPLITTER = '^\\\\(\\\\*)(\[---+\].*?(\n|$))'
-SPECLINE_SPLIT = '(?:\s+|^)via\s+'
+SPLITTER = r'^\[---+\](?P<header>.*?)(\n|$)'
+ESCAPED_SPLITTER = r'^\\(\\*)(\[---+\].*?(\n|$))'
+SPECLINE_SPLIT = r'(?:\s+|^)via\s+'
 
 SPLITTER = re.compile(SPLITTER, re.MULTILINE)
 ESCAPED_SPLITTER = re.compile(ESCAPED_SPLITTER, re.MULTILINE)

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,6 +1,6 @@
 coverage>=3.7.1
 cov-core>=1.7
 py>=1.4.20
-pyflakes
+pyflakes<2.1.0  # https://github.com/AspenWeb/aspen.py/pull/66#issuecomment-458478727
 pytest>=2.5.2
 pytest-cov>=1.6

--- a/tests/test_json_resource.py
+++ b/tests/test_json_resource.py
@@ -59,7 +59,7 @@ def test_json_content_type_is_per_file_configurable(harness):
 
 def test_json_handles_unicode(harness):
     expected = b'''{
-    "Greetings": "\u00b5"
+    "Greetings": "\\u00b5"
 }'''
     actual = harness.simple('''
         from six import unichr

--- a/tests/test_resources_generics.py
+++ b/tests/test_resources_generics.py
@@ -88,34 +88,34 @@ def check_escape(content_to_escape, expected):
     assert actual == expected, repr(actual) + " should be " + repr(expected)
 
 def test_basic_escape_1():
-    check_escape('\[---]', '[---]')
+    check_escape(r'\[---]', '[---]')
 
 def test_basic_escape_2():
-    check_escape('\\\\\\[---]', '\\\[---]')
+    check_escape(r'\\\[---]', r'\\[---]')
 
 def test_inline_sep_ignored_1():
     check_escape('inline[---]break', 'inline[---]break')
 
 def test_inline_sep_ignored_2():
-    check_escape('inline\\\[---]break', 'inline\\\[---]break')
+    check_escape(r'inline\\[---]break', r'inline\\[---]break')
 
 def test_escape_preserves_extra_content():
-    check_escape('\\\\[---] content ', '\[---] content ')
+    check_escape(r'\\[---] content ', r'\[---] content ')
 
 def test_multiple_escapes():
-    to_escape = '1\n\[---]\n2\n\[---]'
+    to_escape = '1\n\\[---]\n2\n\\[---]'
     result = '1\n[---]\n2\n[---]'
     check_escape(to_escape, result)
 
 def test_long_break():
-    check_escape('\[----------]', '[----------]')
+    check_escape(r'\[----------]', '[----------]')
 
 def test_escaped_pages():
     raw = '''\
 1
 [---]
 2
-\[---]
+\\[---]
 3
 '''
     check_page_content(raw, ['1\n', '2\n\\[---]\n3\n'])


### PR DESCRIPTION
Recent versions of Python emit warnings when they encounter string literals containing invalid escape sequences.