### PR TITLE
Representations of `DispatchResult` and `Node` objects

### DIFF
--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -12,7 +12,7 @@ import posixpath
 
 from ..exceptions import SlugCollision, WildcardCollision
 
-from ..utils import Constant
+from ..utils import auto_repr, Constant
 
 
 def debug_noop(msg, *args):
@@ -63,6 +63,7 @@ class DispatchStatus(object):
     "Found a matching node, but it's a directory without an index."
 
 
+@auto_repr
 class DispatchResult(object):
     """The result of a dispatch operation."""
 
@@ -88,6 +89,7 @@ class DispatchResult(object):
 MISSING = DispatchResult(DispatchStatus.missing, None, None, None, None)
 
 
+@auto_repr
 class Node(object):
     """A node of a dispatch tree."""
 

--- a/aspen/utils.py
+++ b/aspen/utils.py
@@ -1,4 +1,35 @@
 
+REPR_TEMPLATE = """
+def __repr__(self):
+    return '{}({})' % ({})
+"""
+
+def auto_repr(cls):
+    """Generates a `__repr__` method for the given class, using `__slots__`.
+
+    >>> @auto_repr
+    ... class Foo(object):
+    ...     __slots__ = ['bar']
+    ...     def __init__(self, bar):
+    ...         self.bar = bar
+
+    >>> Foo(0)
+    Foo(bar=0)
+    """
+    slots = cls.__slots__
+    repr_slots = ', '.join('{}=%r'.format(attr) for attr in slots)
+    repr_values = ', '.join('self.' + attr for attr in slots)
+    repr_def = REPR_TEMPLATE.format(cls.__name__, repr_slots, repr_values)
+    namespace = dict(__name__='auto_repr_%s' % cls.__name__)
+    exec(repr_def, namespace)
+    cls.__repr__ = namespace['__repr__']
+    try:
+        cls.__repr__._source = repr_def
+    except AttributeError:
+        pass
+    return cls
+
+
 class Constant(object):
     """A simple class that creates lightweight constants.
 


### PR DESCRIPTION
This commit adds `__repr__` methods to the `DispatchResult` and `Node` classes. The fun part is that these methods are automatically generated, like what `namedtuple` does.