### PR TITLE
Fix the detection of duplicate path variables

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -61,3 +61,10 @@ class WildcardCollision(Exception):
 
     Examples: ``www/%foo/%foo/index.spt``, ``www/%foo/bar/%foo.spt``.
     """
+
+    def __init__(self, varname, fspath):
+        self.varname = varname
+        self.fspath = fspath
+
+    def __str__(self):
+        return "%r appears twice in the filesystem path %r" % ('%' + self.varname, self.fspath)

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -580,11 +580,9 @@ class UserlandDispatcher(Dispatcher):
                 slug = name
             if slug.startswith('%') and node_type != 'static':
                 varname, vartype, extension = self.split_wildcard(slug[1:], is_dir)
-                if varname in varnames and varnames[varname] != dirpath:
-                    raise WildcardCollision(varname)
-                varnames[varname] = dirpath
+                if varname in varnames:
+                    raise WildcardCollision(varname, fspath)
                 wildcard = '.'.join((varname, vartype)) if vartype else varname
-                del varname, vartype
                 if is_dir:
                     slug = self.DIR_WILDCARD
                 else:
@@ -595,7 +593,12 @@ class UserlandDispatcher(Dispatcher):
             else:
                 wildcard, extension = None, None
             if is_dir:
-                subtree, mtime = self._build_subtree(fspath, varnames.copy())
+                if wildcard:
+                    subvarnames = varnames.copy()
+                    subvarnames[varname] = fspath
+                else:
+                    subvarnames = varnames
+                subtree, mtime = self._build_subtree(fspath, subvarnames)
                 node = self.make_dir_node(fspath, wildcard, subtree, mtime)
             else:
                 node = FileNode(fspath, node_type, wildcard, extension)


### PR DESCRIPTION
This branch fixes the code that determines when the `WildcardCollision` exception should be raised.