### PR TITLE
Improve dispatchers

### DIFF
--- a/aspen/exceptions.py
+++ b/aspen/exceptions.py
@@ -56,6 +56,22 @@ class SlugCollision(Exception):
     Example: ``foo.html`` and ``foo.html.spt`` both claim ``/foo.html``.
     """
 
+    def __init__(self, slug, node1, node2):
+        self.slug = slug
+        self.node1 = node1
+        self.node2 = node2
+
+    def __str__(self):
+        return (
+            "The URL segment %r is claimed by two different nodes:\n"
+            "%s(fspath=%r, type=%r, ...) and\n"
+            "%s(fspath=%r, type=%r, ...)"
+        ) % (
+            self.slug,
+            self.node1.__class__.__name__, self.node1.fspath, self.node1.type,
+            self.node2.__class__.__name__, self.node2.fspath, self.node2.type,
+        )
+
 class WildcardCollision(Exception):
     """Raised if a filesystem path contains multiple wildcards with the same name.
 

--- a/aspen/request_processor/__init__.py
+++ b/aspen/request_processor/__init__.py
@@ -130,7 +130,8 @@ class RequestProcessor(object):
                 HybridDispatcher if self.changes_reload else UserlandDispatcher
             )
         self.dispatcher = self.dispatcher_class(
-            self.www_root, self.is_dynamic, self.indices, self.typecasters
+            self.www_root, self.is_dynamic, self.indices, self.typecasters,
+            **kwargs.get('dispatcher_options', {})
         )
 
         # mime.types

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -277,7 +277,7 @@ class Dispatcher(object):
 
     def __init__(
         self, www_root, is_dynamic, indices, typecasters,
-        file_skipper=skip_hidden_files, collision_handler=legacy_collision_handler
+        file_skipper=skip_hidden_files, collision_handler=hybrid_collision_handler
     ):
         self.www_root = os.path.realpath(www_root)
         self.is_dynamic = is_dynamic

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -163,7 +163,7 @@ class DirectoryNode(object):
         "The name of the path variable if the node is a wildcard."
 
         self.children = children
-        "The node's children, a 2-tuple of dicts: ``(files, dirs)``."
+        "The node's children as a dict (keys are names and values are nodes)."
 
 
 @auto_repr
@@ -182,7 +182,7 @@ class LiveDirectoryNode(object):
         "The name of the path variable if the node is a wildcard."
 
         self._children = children
-        "The node's children, a 2-tuple of dicts: ``(files, dirs)``."
+        "The node's children as a dict (keys are names and values are nodes)."
 
         self.mtime = mtime
         "The last modification time of the directory, in nanoseconds."
@@ -210,6 +210,10 @@ class LiveDirectoryNode(object):
 def legacy_collision_handler(slug, node1, node2):
     """Ignores all collisions, like :class:`SystemDispatcher` does.
     """
+    if node1.type == 'directory' and node2.type != 'directory':
+        if not node1.children:
+            # Ignore empty directory
+            return 'replace_first_node'
     return 'ignore_second_node'
 
 
@@ -224,7 +228,12 @@ def hybrid_collision_handler(slug, node1, node2):
 
     Example: ``/file.js`` will be preferred over ``/file.js.spt``.
     """
-    if node2.type == 'dynamic' and node2.fspath.startswith(node1.fspath + '.'):
+    if node1.type == 'directory' and node2.type != 'directory':
+        if not node1.children:
+            # Ignore empty directory
+            return 'replace_first_node'
+    elif node1.type == 'static' and node2.type == 'dynamic':
+        # Allow `/foo.css` to shadow `/foo.css.spt`
         return 'ignore_second_node'
     return 'raise'
 
@@ -555,7 +564,7 @@ class UserlandDispatcher(Dispatcher):
     def _build_subtree(self, dirpath, varnames):
         """This method recursively builds a dispacth subtree.
         """
-        files, dirs = {}, {}
+        children = {}
         mtime = get_mtime_ns(dirpath)
         index = self.find_index(dirpath)
         for entry in sorted(scandir(dirpath), key=attrgetter('name')):
@@ -587,7 +596,7 @@ class UserlandDispatcher(Dispatcher):
                     slug = self.DIR_WILDCARD
                 else:
                     node = FileNode(fspath, node_type, wildcard, extension)
-                    wildleafs = files.setdefault(self.LEAF_WILDCARDS, {})
+                    wildleafs = children.setdefault(self.LEAF_WILDCARDS, {})
                     wildleafs[extension] = node
                     continue
             else:
@@ -602,21 +611,21 @@ class UserlandDispatcher(Dispatcher):
                 node = self.make_dir_node(fspath, wildcard, subtree, mtime)
             else:
                 node = FileNode(fspath, node_type, wildcard, extension)
-            goes_into = dirs if is_dir else files
-            if slug in goes_into:
-                action = self.collision_handler(slug, goes_into[slug], node)
+            if slug in children:
+                previous = children[slug]
+                action = self.collision_handler(slug, previous, node)
                 debug("collision: %r is claimed by both %r and %r | action: %r"
-                     , slug, goes_into[slug].fspath, node.fspath, action)
+                     , slug, previous.fspath, node.fspath, action)
                 if action == 'raise':
-                    raise SlugCollision(slug, goes_into[slug], node)
+                    raise SlugCollision(slug, previous, node)
                 if action == 'ignore_second_node':
                     continue
                 if action != 'replace_first_node':
                     raise ValueError("%r is not a valid collision action" % action)
-            goes_into[slug] = node
+            children[slug] = node
             if fspath == index:
-                files[''] = slug
-        return (files, dirs), mtime
+                children[''] = node
+        return children, mtime
 
     def dispatch(self, path, path_segments):
         """"""
@@ -664,42 +673,40 @@ class UserlandDispatcher(Dispatcher):
         node = self.tree
         max_depth = len(path_segments) - 1
         for depth, segment in enumerate(path_segments):
-            files, dirs = node.children
+            children = node.children
 
             if segment:
-                # The segment isn't empty. Look for a match in files and dirs.
-                if segment in files:
-                    debug("exact file match: %r", segment)
-                    node = files[segment]
+                # The segment isn't empty. Look for a match in children.
+                if segment in children:
+                    node = children[segment]
+                    debug("exact match: %r -> %r", segment, node)
+                    if node.type == 'directory':
+                        continue
                     if depth == max_depth:
-                        if segment == files.get(''):
+                        if node is children.get(''):
                             # The canonical path of `/index.html` is `/`
                             canonical = path[:-len(segment)]
                         return success()
                 if depth == max_depth and '.' in segment:
                     base, extension = segment.rsplit('.', 1)
-                    if base in files and files[base].type == 'dynamic':
+                    if base in children and children[base].type == 'dynamic':
                         # Base match (e.g. `foo.spt` for `/foo.json`)
-                        debug("base match: %r", base)
-                        node = files[base]
+                        node = children[base]
+                        debug("base match: %r -> %r", base, node)
                         if segment == node.fspath.rsplit(os.path.sep, 1)[-1]:
                             # Don't route a request for `/bar.html.spt` to `bar.html.spt`
                             return MISSING
                         return success()
                     extension = None
-                if segment in dirs:
-                    debug("exact directory match: %r", segment)
-                    node = dirs[segment]
-                    continue
             elif depth == max_depth:
                 # The segment is empty and it's the last one.
                 break
 
             # This segment hasn't matched anything so far, look for wildcards.
-            if LEAF_WILDCARDS in files:
-                fallback_wildleafs = (files[LEAF_WILDCARDS], depth)
+            if LEAF_WILDCARDS in children:
+                fallback_wildleafs = (children[LEAF_WILDCARDS], depth)
                 debug("found fallback wildleafs: %r", fallback_wildleafs)
-            if DIR_WILDCARD in dirs:
+            if DIR_WILDCARD in children:
                 # Try to find a wildleaf match first, so that `/foo.txt` matches
                 # `/%bar.txt.spt` instead of `/%dir/`.
                 if fallback_wildleafs and depth == max_depth:
@@ -708,7 +715,7 @@ class UserlandDispatcher(Dispatcher):
                         return result
                 # No suitable wildleaf was found, match the virtual directory.
                 # Note: empty segments are allowed on purpose.
-                node = dirs[DIR_WILDCARD]
+                node = children[DIR_WILDCARD]
                 debug("virtual directory match: %r", node.wildcard)
                 wildcards[node.wildcard] = segment
                 continue
@@ -717,15 +724,15 @@ class UserlandDispatcher(Dispatcher):
 
         if node.type == 'directory':
             debug("final node is a directory")
-            files, dirs = node.children
+            children = node.children
             canonical = path + '/' if path_segments[-1] != '' else None
             # Look for an index file
-            if '' in files:
+            if '' in children:
                 debug("index match")
-                node = files[files['']]
-            elif LEAF_WILDCARDS in files:
+                node = children['']
+            elif LEAF_WILDCARDS in children:
                 debug("wildleaf match")
-                wildleafs = files[LEAF_WILDCARDS]
+                wildleafs = children[LEAF_WILDCARDS]
                 # Legacy behavior: dispatch to the "first" wildleaf
                 node = wildleafs[min(wildleafs)]
                 wildcards[node.wildcard] = ''

--- a/tests/dispatch_table_data.rst
+++ b/tests/dispatch_table_data.rst
@@ -4,24 +4,23 @@ index bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                    
 ===== ======= ======= =========== ======== ==== =========  =====================  ========================  =========================  ============================  ================================
   #   1 file
   X      _       _         _          _      _      _      ok index               -                         -                          -                             -
-  _      X       _         _          _      _      _      ui /                   ok bar.spt                -                          ok bar.spt                    -
+  _      X       _         _          _      _      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.spt                    -
   _      _       X         _          _      _      _      ui /                   -                         -                          ok bar.txt                    -
   _      _       _         X          _      _      _      ui /                   -                         -                          ok bar.txt.spt                -
   _      _       _         _          X      _      _      ok %bar.spt (bar='')   ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok %bar.spt (bar='bar.txt')   ok %bar.spt (bar='bar.txt/')
   _      _       _         _          _      X      _      ui /                   ui bar/ @/bar/            ui bar/                    -                             -
   _      _       _         _          _      _      X      ui /                   ok bar/index @/bar/       ok bar/index               -                             -
   #   2 files
-  X      X       _         _          _      _      _      ok index               ok bar.spt                -                          ok bar.spt                    -
+  X      X       _         _          _      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.spt                    -
   X      _       X         _          _      _      _      ok index               -                         -                          ok bar.txt                    -
   X      _       _         X          _      _      _      ok index               -                         -                          ok bar.txt.spt                -
   X      _       _         _          X      _      _      ok index               ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok %bar.spt (bar='bar.txt')   ok %bar.spt (bar='bar.txt/')
   X      _       _         _          _      X      _      ok index               ui bar/ @/bar/            ui bar/                    -                             -
   X      _       _         _          _      _      X      ok index               ok bar/index @/bar/       ok bar/index               -                             -
-  _      X       X         _          _      _      _      ui /                   ok bar.spt                -                          ok bar.txt                    -
-  _      X       _         X          _      _      _      ui /                   ok bar.spt                -                          ok bar.txt.spt                -
-  _      X       _         _          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.spt                    ok %bar.spt (bar='bar.txt/')
-  _      X       _         _          _      X      _      ui /                   ok bar.spt                ui bar/                    ok bar.spt                    -
-  _      X       _         _          _      _      X      ui /                   ok bar.spt                ok bar/index               ok bar.spt                    -
+  _      X       X         _          _      _      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  _      X       _         X          _      _      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                -
+  _      X       _         _          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.spt                    ok %bar.spt (bar='bar.txt/')
+  _      X       _         _          _      X      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.spt                    -
   _      _       X         X          _      _      _      ui /                   -                         -                          ok bar.txt                    -
   _      _       X         _          X      _      _      ok %bar.spt (bar='')   ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   _      _       X         _          _      X      _      ui /                   ui bar/ @/bar/            ui bar/                    ok bar.txt                    -
@@ -35,11 +34,10 @@ index bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                    
 #ndex bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                      /bar                      /bar/                      /bar.txt                      /bar.txt/
 #==== ======= ======= =========== ======== ==== =========  =====================  ========================  =========================  ============================  ================================
   #   3 files
-  X      X       X         _          _      _      _      ok index               ok bar.spt                -                          ok bar.txt                    -
-  X      X       _         X          _      _      _      ok index               ok bar.spt                -                          ok bar.txt.spt                -
-  X      X       _         _          X      _      _      ok index               ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.spt                    ok %bar.spt (bar='bar.txt/')
-  X      X       _         _          _      X      _      ok index               ok bar.spt                ui bar/                    ok bar.spt                    -
-  X      X       _         _          _      _      X      ok index               ok bar.spt                ok bar/index               ok bar.spt                    -
+  X      X       X         _          _      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  X      X       _         X          _      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                -
+  X      X       _         _          X      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.spt                    ok %bar.spt (bar='bar.txt/')
+  X      X       _         _          _      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.spt                    -
   X      _       X         X          _      _      _      ok index               -                         -                          ok bar.txt                    -
   X      _       X         _          X      _      _      ok index               ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   X      _       X         _          _      X      _      ok index               ui bar/ @/bar/            ui bar/                    ok bar.txt                    -
@@ -49,15 +47,12 @@ index bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                    
   X      _       _         X          _      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok bar.txt.spt                -
   X      _       _         _          X      X      _      ok index               ui bar/ @/bar/            ui bar/                    ok %bar.spt (bar='bar.txt')   ok %bar.spt (bar='bar.txt/')
   X      _       _         _          X      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok %bar.spt (bar='bar.txt')   ok %bar.spt (bar='bar.txt/')
-  _      X       X         X          _      _      _      ui /                   ok bar.spt                -                          ok bar.txt                    -
-  _      X       X         _          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  _      X       X         _          _      X      _      ui /                   ok bar.spt                ui bar/                    ok bar.txt                    -
-  _      X       X         _          _      _      X      ui /                   ok bar.spt                ok bar/index               ok bar.txt                    -
-  _      X       _         X          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
-  _      X       _         X          _      X      _      ui /                   ok bar.spt                ui bar/                    ok bar.txt.spt                -
-  _      X       _         X          _      _      X      ui /                   ok bar.spt                ok bar/index               ok bar.txt.spt                -
-  _      X       _         _          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ui bar/                    ok bar.spt                    ok %bar.spt (bar='bar.txt/')
-  _      X       _         _          X      _      X      ok %bar.spt (bar='')   ok bar.spt                ok bar/index               ok bar.spt                    ok %bar.spt (bar='bar.txt/')
+  _      X       X         X          _      _      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  _      X       X         _          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  _      X       X         _          _      X      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  _      X       _         X          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
+  _      X       _         X          _      X      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                -
+  _      X       _         _          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.spt                    ok %bar.spt (bar='bar.txt/')
   _      _       X         X          X      _      _      ok %bar.spt (bar='')   ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   _      _       X         X          _      X      _      ui /                   ui bar/ @/bar/            ui bar/                    ok bar.txt                    -
   _      _       X         X          _      _      X      ui /                   ok bar/index @/bar/       ok bar/index               ok bar.txt                    -
@@ -69,15 +64,12 @@ index bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                    
 #ndex bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                      /bar                      /bar/                      /bar.txt                      /bar.txt/
 #==== ======= ======= =========== ======== ==== =========  =====================  ========================  =========================  ============================  ================================
   #   4 files
-  X      X       X         X          _      _      _      ok index               ok bar.spt                -                          ok bar.txt                    -
-  X      X       X         _          X      _      _      ok index               ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  X      X       X         _          _      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt                    -
-  X      X       X         _          _      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt                    -
-  X      X       _         X          X      _      _      ok index               ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
-  X      X       _         X          _      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt.spt                -
-  X      X       _         X          _      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt.spt                -
-  X      X       _         _          X      X      _      ok index               ok bar.spt                ui bar/                    ok bar.spt                    ok %bar.spt (bar='bar.txt/')
-  X      X       _         _          X      _      X      ok index               ok bar.spt                ok bar/index               ok bar.spt                    ok %bar.spt (bar='bar.txt/')
+  X      X       X         X          _      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  X      X       X         _          X      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  X      X       X         _          _      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  X      X       _         X          X      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
+  X      X       _         X          _      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                -
+  X      X       _         _          X      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.spt                    ok %bar.spt (bar='bar.txt/')
   X      _       X         X          X      _      _      ok index               ok %bar.spt (bar='bar')   ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   X      _       X         X          _      X      _      ok index               ui bar/ @/bar/            ui bar/                    ok bar.txt                    -
   X      _       X         X          _      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok bar.txt                    -
@@ -85,28 +77,21 @@ index bar.spt bar.txt bar.txt.spt %bar.spt bar/ bar/index  /                    
   X      _       X         _          X      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   X      _       _         X          X      X      _      ok index               ui bar/ @/bar/            ui bar/                    ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
   X      _       _         X          X      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
-  -      X       X         X          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  -      X       X         X          _      X      _      ui /                   ok bar.spt                ui bar/                    ok bar.txt                    -
-  -      X       X         X          _      _      X      ui /                   ok bar.spt                ok bar/index               ok bar.txt                    -
-  -      X       _         X          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ui bar/                    ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
-  -      X       _         X          X      _      X      ok %bar.spt (bar='')   ok bar.spt                ok bar/index               ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
+  -      X       X         X          X      _      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  -      X       X         X          _      X      _      ui /                   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  -      X       _         X          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
   -      _       X         X          X      X      _      ok %bar.spt (bar='')   ui bar/ @/bar/            ui bar/                    ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   -      _       X         X          X      _      X      ok %bar.spt (bar='')   ok bar/index @/bar/       ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   #   5 files
-  X      X       X         X          X      _      _      ok index               ok bar.spt                ok %bar.spt (bar='bar/')   ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  X      X       X         X          _      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt                    -
-  X      X       X         X          _      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt                    -
-  X      X       X         _          X      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  X      X       X         _          X      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  X      X       _         X          X      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
-  X      X       _         X          X      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
+  X      X       X         X          X      _      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  X      X       X         X          _      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    -
+  X      X       X         _          X      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  X      X       _         X          X      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt.spt                ok %bar.spt (bar='bar.txt/')
   X      _       X         X          X      X      _      ok index               ui bar/ @/bar/            ui bar/                    ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   X      _       X         X          X      _      X      ok index               ok bar/index @/bar/       ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  _      X       X         X          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ui bar/                    ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  _      X       X         X          X      _      X      ok %bar.spt (bar='')   ok bar.spt                ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  _      X       X         X          X      X      _      ok %bar.spt (bar='')   ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
   #   6 files
-  X      X       X         X          X      X      _      ok index               ok bar.spt                ui bar/                    ok bar.txt                    ok %bar.spt (bar='bar.txt/')
-  X      X       X         X          X      _      X      ok index               ok bar.spt                ok bar/index               ok bar.txt                    ok %bar.spt (bar='bar.txt/')
+  X      X       X         X          X      X      _      ok index               ok bar.spt                ok bar.spt @/bar           ok bar.txt                    ok %bar.spt (bar='bar.txt/')
 ===== ======= ======= =========== ======== ==== =========  =====================  ========================  =========================  ============================  ================================
 
 Notes:
@@ -117,7 +102,7 @@ Notes:
     * requesting /foo.html will check/return approximately: foo.html, foo.html.spt, foo.spt, foo.html/, %*.html.spt, %*.spt
 
   * Note that bar/ and bar/index in the above are mutually exclusive since bar/index implies the existence of bar/
-  * There should be 2^5 * 3 lines data lines: on/off for the files except the last two have only 3 possibilites: [ bar/, bar/index, nothing ]
+  * Moreover bar.spt is incompatible with bar/index because mixing them would result in /bar and /bar/ resolving differently
 
 Future work:
 ============

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -32,6 +32,14 @@ def assert_missing(harness, request_path):
     assert result.status == DispatchStatus.missing
     assert result.match is None
 
+def assert_unindexed(harness, request_path, wildcards=None, extension=None, canonical=None):
+    result = harness.request_processor.dispatch(Path(request_path))
+    assert result.status == DispatchStatus.unindexed
+    assert result.match == harness.fs.www.resolve(request_path) + os.path.sep
+    assert result.wildcards == wildcards
+    assert result.extension == extension
+    assert result.canonical == canonical
+
 def assert_wildcards(harness, request_path, expected_vals):
     result = harness.request_processor.dispatch(Path(request_path))
     assert result.wildcards == expected_vals
@@ -111,36 +119,25 @@ def test_dispatch_when_filesystem_has_been_modified():
 # Indices
 # =======
 
-def test_index_is_found(harness):
+def test_static_index(harness):
     harness.fs.www.mk(('index.html', 'Greetings, program!'))
     assert_match(harness, '/', 'index.html')
 
-def test_negotiated_index_is_found(harness):
-    harness.fs.www.mk(('index.spt', '''
-        [----------] text/html
-        <h1>Greetings, program!</h1>
-        [----------] text/plain
-        Greetings, program!
-    '''))
+def test_index_without_extention(harness):
+    harness.fs.www.mk(('index', 'Greetings, program!'))
+    assert_match(harness, '/', 'index')
+
+def test_dynamic_index(harness):
+    harness.fs.www.mk(('index.spt', NEGOTIATED_SIMPLATE))
     assert_match(harness, '/', 'index.spt')
 
 def test_empty_root(harness):
-    result = dispatch(harness, '/')
-    assert result.status == DispatchStatus.unindexed
-    assert result.match == harness.fs.www.root + os.path.sep
-    assert result.wildcards is None
-    assert result.extension is None
-    assert result.canonical is None
+    assert_unindexed(harness, '/')
 
 def test_unrecognized_index(harness):
     harness.fs.www.mk(('index.html', "Greetings, program!"),)
     harness.hydrate_request_processor(indices=["default.html"])
-    result = dispatch(harness, '/')
-    assert result.status == DispatchStatus.unindexed
-    assert result.match == harness.fs.www.root + os.path.sep
-    assert result.wildcards is None
-    assert result.extension is None
-    assert result.canonical is None
+    assert_unindexed(harness, '/')
 
 def test_dispatcher_matches_second_index_if_first_is_missing(harness):
     harness.fs.www.mk(('default.html', "Greetings, program!"),)
@@ -372,10 +369,7 @@ def test_dispatcher_passes_through_virtual_dir_with_trailing_slash(harness):
 
 def test_dispatcher_matches_dir_even_without_trailing_slash(harness):
     harness.fs.www.mk('foo',)
-    result = dispatch(harness, '/foo')
-    assert result.status == DispatchStatus.unindexed
-    assert result.match == harness.fs.www.resolve('foo') + os.path.sep
-    assert result.canonical == '/foo/'
+    assert_unindexed(harness, '/foo', canonical='/foo/')
 
 def test_dispatcher_matches_virtual_dir_even_without_trailing_slash(harness):
     harness.fs.www.mk('%foo',)
@@ -409,6 +403,7 @@ def test_missing_trailing_slash_matches_wild_leaf(harness):
 
 def test_dont_confuse_files_for_dirs(harness):
     harness.fs.www.mk(('foo.html', 'Greetings, Program!'),)
+    assert_missing(harness, '/foo.html/')
     assert_missing(harness, '/foo.html/bar')
 
 def test_wildleaf_with_extention_doesnt_match_trailing_slash(harness):

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -439,6 +439,15 @@ def test_wildleaf_without_extention_matches_trailing_slash(harness):
     assert_match(harness, '/chad/cheddar.txt/', '%name/%cheese.spt',
                  wildcards={'name': 'chad', 'cheese': 'cheddar.txt/'})
 
+def test_extra_slash_matches(harness):
+    harness.fs.www.mk(('foo/bar.spt', ''))
+    assert_match(harness, '/foo/bar/', 'foo/bar.spt', canonical='/foo/bar')
+
+def test_resource_in_parent_directory_is_used_as_index(harness):
+    harness.fs.www.mk(('foo/bar.spt', ''))
+    harness.fs.www.mk(('foo/bar/baz.spt', ''))
+    assert_match(harness, '/foo/bar/', 'foo/bar.spt')
+
 
 # path part params
 # ================


### PR DESCRIPTION
This branch does three things, which are bundled into a single PR because they're related and difficult to untangle:

- it adds the detection of collisions between files like `/bar.spt` and `/bar/index.spt`
- it changes the default collision handler from the legacy one to a new one
- it changes the dispatch rules so that requests for the path `/bar/` can be matched to `/bar.spt`