### PR TITLE
Lazy dispatch tree building

### DIFF
--- a/aspen/request_processor/__init__.py
+++ b/aspen/request_processor/__init__.py
@@ -133,6 +133,7 @@ class RequestProcessor(object):
             self.www_root, self.is_dynamic, self.indices, self.typecasters,
             **kwargs.get('dispatcher_options', {})
         )
+        self.dispatcher.build_dispatch_tree()
 
         # mime.types
         # ==========

--- a/aspen/request_processor/dispatcher.py
+++ b/aspen/request_processor/dispatcher.py
@@ -291,10 +291,9 @@ class Dispatcher(object):
         self.typecasters = typecasters
         self.file_skipper = file_skipper
         self.collision_handler = collision_handler
-        self.build_dispatch_tree()
 
     def build_dispatch_tree(self):
-        """Called by :meth:`.__init__` to build the dispatch tree.
+        """Called to build the dispatch tree.
 
         Subclasses **must** implement this method.
         """

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -69,6 +69,7 @@ def test_dispatcher_returns_a_result(dispatcher_class):
         indices     = ['index.html'],
         typecasters = {},
     )
+    dispatcher.build_dispatch_tree()
     result = dispatcher.dispatch('/', [''])
     assert result.status == DispatchStatus.okay
     assert result.match == os.path.join(www.root, 'index.html')
@@ -83,6 +84,7 @@ def test_dispatcher_returns_unindexed_for_unindexed_directory(dispatcher_class):
         indices     = [],
         typecasters = {},
     )
+    dispatcher.build_dispatch_tree()
     r = dispatcher.dispatch('/', [''])
     assert r.status == DispatchStatus.unindexed
     assert r.match == www.root + os.path.sep
@@ -102,6 +104,7 @@ def test_dispatch_when_filesystem_has_been_modified():
             indices     = ['index.html'],
             typecasters = {},
         ))
+        dispatchers[-1].build_dispatch_tree()
     # Now add an index file and try to dispatch
     www.mk(('index.html', 'Greetings, program!'))
     for dispatcher in dispatchers:


### PR DESCRIPTION
This commit removes the call to `build_dispatch_tree()` from `Dispatcher.__init__()`, so that it can easily be delayed if desired.