### PR TITLE
`Mapping` cleanup

### DIFF
--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -44,11 +44,10 @@ class Mapping(dict):
         """
         raise
 
-    def pop(self, name, default=NO_DEFAULT):
-        """Given a name, return a value.
+    def poplast(self, name, default=NO_DEFAULT):
+        """Remove and return the last value of the list for the `name` key.
 
-        This removes the last value from the list for name and returns it. If
-        there was only one value in the list then the key is removed from the
+        If there is only one value in the list, then the key is removed from the
         mapping. If name is not present and default is given, that is returned
         instead. Otherwise, self.keyerror is called.
 
@@ -63,8 +62,6 @@ class Mapping(dict):
         if not values:
             del self[name]
         return value
-
-    popall = dict.pop
 
     def all(self, name):
         """Given a name, return a list of values, possibly empty.

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -1,4 +1,7 @@
-NO_DEFAULT = object()
+from ..utils import Constant
+
+
+NO_DEFAULT = Constant('NO_DEFAULT')
 
 
 class Mapping(dict):

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -14,6 +14,13 @@ class Mapping(dict):
 
     """
 
+    def __init__(self, *a, **kw):
+        super().__init__(*a)
+        for k, v in self.items():
+            dict.__setitem__(self, k, v.copy())
+        for k, v in kw.items():
+            self[k] = v
+
     def __getitem__(self, name):
         """Given a name, return the last value or call self.keyerror.
         """
@@ -26,6 +33,11 @@ class Mapping(dict):
         """Given a name and value, clobber any existing values.
         """
         dict.__setitem__(self, name, [value])
+
+    def copy(self):
+        return self.__class__(self)
+
+    copy.__doc__ = dict.copy.__doc__
 
     def keyerror(self, key):
         """Called when a key is missing. Default implementation simply reraises.

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -83,3 +83,9 @@ class Mapping(dict):
             self.all(name).append(value)
         else:
             dict.__setitem__(self, name, [value])
+
+    def setdefault(self, name, value):
+        """Set the value for the `name` key if there is none.
+        """
+        if name not in self:
+            self[name] = value

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -71,13 +71,3 @@ class Mapping(dict):
             self.all(name).append(value)
         else:
             dict.__setitem__(self, name, [value])
-
-    def ones(self, *names):
-        """Given one or more names of keys, return a list of their values.
-        """
-        lowered = []
-        for name in names:
-            n = name.lower()
-            if n not in lowered:
-                lowered.append(n)
-        return [self[name] for name in lowered]

--- a/aspen/http/mapping.py
+++ b/aspen/http/mapping.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 from ..utils import Constant
 
 
@@ -7,85 +9,154 @@ NO_DEFAULT = Constant('NO_DEFAULT')
 class Mapping(dict):
     """Base class for HTTP mappings.
 
-    Mappings in HTTP differ from Python dictionaries in that they may have one
-    or more values. This dictionary subclass maintains a list of values for
-    each key. However, access semantics are asymmetric: subscript assignment
-    clobbers to list, while subscript access returns the last item. Think
-    about it.
+    This dictionary subclass maintains a list of values for each key. However,
+    since most of the time only one value is expected and wanted for each key,
+    the standard `dict` methods reimplemented by this class act as if there was
+    only one value per key.
+
+    Example:
+
+    >>> m = Mapping([('a', '1')])
+    >>> m
+    Mapping({'a': ['1']})
+    >>> m['a']
+    '1'
+    >>> m.append('a', '2')
+    >>> m['a']
+    '2'
+    >>> m.all('a')
+    ['1', '2']
+    >>> m.pop('a')
+    '2'
+    >>> m['a']
+    Traceback (most recent call last):
+      ...
+    KeyError: 'a'
 
     .. warning:: This isn't thread-safe.
 
     """
 
     def __init__(self, *a, **kw):
-        super().__init__(*a)
-        for k, v in self.items():
-            dict.__setitem__(self, k, v.copy())
-        for k, v in kw.items():
-            self[k] = v
+        self.update(*a, **kw)
+
+    def __eq__(self, other):
+        keys = self.keys()
+        if keys != other.keys():
+            return False
+        for k in keys:
+            theirs = other[k]
+            ours = self.all(k) if isinstance(theirs, (list, tuple)) else self[k]
+            if ours != theirs:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def __getitem__(self, name):
-        """Given a name, return the last value or call self.keyerror.
-        """
-        try:
-            return dict.__getitem__(self, name)[-1]
-        except KeyError:
-            self.keyerror(name)
+        return super().__getitem__(name)[-1]
+
+    def __missing__(self, name):
+        raise KeyError(name) from None
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({super().__repr__()})"
 
     def __setitem__(self, name, value):
-        """Given a name and value, clobber any existing values.
-        """
-        dict.__setitem__(self, name, [value])
+        super().__setitem__(name, [value])
 
     def copy(self):
         return self.__class__(self)
 
     copy.__doc__ = dict.copy.__doc__
 
-    def keyerror(self, key):
-        """Called when a key is missing. Default implementation simply reraises.
+    def pop(self, name, default=NO_DEFAULT):
+        """Remove the `name` key from the mapping and return its associated value.
+
+        If `name` is not present and `default` is given, that is returned instead.
+        Otherwise, `self.__missing__(name)` is called, to make it easier for
+        subclasses to raise custom exceptions.
         """
-        raise
+        values = super().pop(name, default)
+        if values and values is not default:
+            return values[-1]
+        elif default is not NO_DEFAULT:
+            return default
+        else:
+            return self.__missing__(name)
 
-    def poplast(self, name, default=NO_DEFAULT):
-        """Remove and return the last value of the list for the `name` key.
-
-        If there is only one value in the list, then the key is removed from the
-        mapping. If name is not present and default is given, that is returned
-        instead. Otherwise, self.keyerror is called.
-
-        """
-        try:
-            values = dict.__getitem__(self, name)
-        except KeyError:
-            if default is not NO_DEFAULT:
-                return default
-            self.keyerror(name)
-        value = values.pop()
-        if not values:
-            del self[name]
-        return value
+    popall = dict.pop
 
     def all(self, name):
-        """Given a name, return a list of values, possibly empty.
+        """Return the list of values for the `name` key, possibly an empty one.
         """
-        return dict.get(self, name, [])
+        return super().get(name, [])
 
     def get(self, name, default=None):
-        """Override to only return the last value.
+        """Return the last value of the list for the `name` key.
         """
-        return dict.get(self, name, [default])[-1]
+        return super().get(name, (default,))[-1]
+
+    last = get
 
     def add(self, name, value):
-        """Given a name and value, clobber any existing values with the new one.
+        """Append `value` to the list for the `name` key.
         """
-        if name in self:
-            self.all(name).append(value)
-        else:
-            dict.__setitem__(self, name, [value])
+        try:
+            super().__getitem__(name).append(value)
+        except KeyError:
+            super().__setitem__(name, [value])
+
+    append = add
+
+    def extend(self, name, values):
+        """Append `values` to the list for the `name` key.
+        """
+        try:
+            super().__getitem__(name).extend(values)
+        except KeyError:
+            super().__setitem__(name, values)
 
     def setdefault(self, name, value):
         """Set the value for the `name` key if there is none.
         """
         if name not in self:
             self[name] = value
+
+    def items(self):
+        """Returns an iterator of `(name, last_value)` tuples.
+        """
+        return ((name, values[-1]) for name, values in super().items())
+
+    def popitem(self):
+        name, values = super().popitem()
+        return (name, values[-1])
+
+    popitem.__doc__ = dict.popitem.__doc__
+
+    def update(self, *a, **kw):
+        """Updates `self` with items from the iterables `*a` and the dict `**kw`.
+        """
+        for it in a:
+            if not it:
+                continue
+            items = it.items() if hasattr(it, 'items') else it
+            for k, v in items:
+                if isinstance(v, str):
+                    self.add(k, v)
+                else:
+                    self.extend(k, v)
+        for k, v in kw.items():
+            self[k] = v
+
+    def values(self):
+        """Returns an iterator yielding the last value for each key.
+        """
+        return map(itemgetter(-1), super().values())
+
+    @classmethod
+    def fromkeys(cls, iterable, value):
+        """Create a new mapping with keys from `iterable` and values set to `value`.
+        """
+        return cls((name, value) for name in iterable)

--- a/aspen/request_processor/typecasting.py
+++ b/aspen/request_processor/typecasting.py
@@ -30,6 +30,6 @@ def apply_typecasters(typecasters, path_vars, context):
                     # path_vars is a Mapping not a dict, so:
                     for v in path_vars.all(part):
                         path_vars.add(var, typecasters[ext](v, context))
-                    path_vars.popall(part)
+                    del path_vars[part]
                 except Exception:
                     raise TypecastError(ext)

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -76,53 +76,44 @@ def test_accessing_missing_key_calls_keyerror():
 
     m.keyerror = raise_foobar
     raises(Foobar, lambda k: m[k], 'foo')
-    raises(Foobar, m.pop, 'foo')
+    raises(Foobar, m.poplast, 'foo')
 
-def test_mapping_pop_returns_the_last_item():
+def test_mapping_poplast_returns_the_last_item_and_leaves_the_rest():
     m = Mapping()
     m['foo'] = 1
-    m.add('foo', 1)
+    m.add('foo', 2)
     m.add('foo', 3)
-    expected = 3
-    actual = m.pop('foo')
-    assert actual == expected
+    popped = m.poplast('foo')
+    assert popped == 3
+    remainder = m.all('foo')
+    assert remainder == [1, 2]
 
-def test_mapping_pop_leaves_the_rest():
+def test_mapping_poplast_removes_the_list_if_it_only_had_one_value():
     m = Mapping()
     m['foo'] = 1
-    m.add('foo', 1)
-    m.add('foo', 3)
-    m.pop('foo')
-    expected = [1, 1]
-    actual = m.all('foo')
-    assert actual == expected
-
-def test_mapping_pop_removes_the_item_if_that_was_the_last_value():
-    m = Mapping()
-    m['foo'] = 1
-    m.pop('foo')
+    m.poplast('foo')
     expected = []
     actual = list(m.keys())
     assert actual == expected
 
-def test_mapping_pop_raises_KeyError_by_default():
+def test_mapping_poplast_raises_KeyError_by_default():
     m = Mapping()
     with raises(KeyError):
-        m.pop('foo')
+        m.poplast('foo')
 
-def test_mapping_popall_returns_a_list():
+def test_mapping_pop_returns_a_list():
     m = Mapping()
     m['foo'] = 1
     m.add('foo', 1)
     m.add('foo', 3)
     expected = [1, 1, 3]
-    actual = m.popall('foo')
+    actual = m.pop('foo')
     assert actual == expected
 
-def test_mapping_popall_removes_the_item():
+def test_mapping_pop_removes_the_item():
     m = Mapping()
     m['foo'] = 1
     m['foo'] = 1
     m['foo'] = 3
-    m.popall('foo')
+    m.pop('foo')
     assert 'foo' not in m

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -65,55 +65,43 @@ def test_mapping_deleting_a_key_removes_it_entirely():
     del m['foo']
     assert 'foo' not in m
 
-def test_accessing_missing_key_calls_keyerror():
-    m = Mapping()
-
+def test_accessing_missing_key():
     class Foobar(Exception):
         pass
 
-    def raise_foobar(self):
-        raise Foobar
+    class FoobarMapping(Mapping):
+        def __missing__(self, name):
+            raise Foobar
 
-    m.keyerror = raise_foobar
+    m = FoobarMapping()
     raises(Foobar, lambda k: m[k], 'foo')
-    raises(Foobar, m.poplast, 'foo')
+    assert m.get('foo') is None
 
-def test_mapping_poplast_returns_the_last_item_and_leaves_the_rest():
+def test_mapping_pop_raises_KeyError_by_default():
+    m = Mapping()
+    with raises(KeyError):
+        m.pop('foo')
+
+def test_mapping_pop_removes_the_list_and_returns_its_last_item():
     m = Mapping()
     m['foo'] = 1
     m.add('foo', 2)
     m.add('foo', 3)
-    popped = m.poplast('foo')
+    popped = m.pop('foo')
     assert popped == 3
-    remainder = m.all('foo')
-    assert remainder == [1, 2]
+    assert 'foo' not in m
 
-def test_mapping_poplast_removes_the_list_if_it_only_had_one_value():
-    m = Mapping()
-    m['foo'] = 1
-    m.poplast('foo')
-    expected = []
-    actual = list(m.keys())
-    assert actual == expected
-
-def test_mapping_poplast_raises_KeyError_by_default():
+def test_mapping_popall_raises_KeyError_by_default():
     m = Mapping()
     with raises(KeyError):
-        m.poplast('foo')
+        m.popall('foo')
 
-def test_mapping_pop_returns_a_list():
+def test_mapping_popall_removes_the_list_and_returns_it():
     m = Mapping()
     m['foo'] = 1
     m.add('foo', 1)
     m.add('foo', 3)
     expected = [1, 1, 3]
-    actual = m.pop('foo')
+    actual = m.popall('foo')
     assert actual == expected
-
-def test_mapping_pop_removes_the_item():
-    m = Mapping()
-    m['foo'] = 1
-    m['foo'] = 1
-    m['foo'] = 3
-    m.pop('foo')
     assert 'foo' not in m

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -57,21 +57,6 @@ def test_mapping_all_returns_empty_list_when_key_is_missing():
     actual = m.all('foo')
     assert actual == expected
 
-def test_mapping_ones_returns_list_of_last_values():
-    m = Mapping()
-    m['foo'] = 1
-    m['foo'] = 2
-    m['bar'] = 3
-    m['bar'] = 4
-    m['bar'] = 5
-    m['baz'] = 6
-    m['baz'] = 7
-    m['baz'] = 8
-    m['baz'] = 9
-    expected = [2, 5, 9]
-    actual = m.ones('foo', 'bar', 'baz')
-    assert actual == expected
-
 def test_mapping_deleting_a_key_removes_it_entirely():
     m = Mapping()
     m['foo'] = 1
@@ -91,7 +76,7 @@ def test_accessing_missing_key_calls_keyerror():
 
     m.keyerror = raise_foobar
     raises(Foobar, lambda k: m[k], 'foo')
-    raises(Foobar, m.ones, 'foo')
+    raises(Foobar, m.pop, 'foo')
 
 def test_mapping_pop_returns_the_last_item():
     m = Mapping()


### PR DESCRIPTION
To avoid confusion and easy mistakes as much as possible, a `Mapping` should behave like a `dict[str, str]` in every way.